### PR TITLE
Remove special validation step for rotate that prevent multibuild to work

### DIFF
--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -2164,10 +2164,6 @@ bool cMain::ValidateStep(const int& row, StepParameters& stepParameters, bool va
 
 			return true;
 
-		case e_rotate:
-			// Set amount of buildings to 1 and go to default
-			stepParameters.Buildings = 1;
-
 		default:
 
 			if (!BuildingExists(BuildingsSnapShot, amountOfBuildings, stepParameters))


### PR DESCRIPTION
Not sure what it was meant to do, but it prevented rotation of more than 1 building.