### PR TITLE
State modifiers

### DIFF
--- a/Lua Files/locale.cfg
+++ b/Lua Files/locale.cfg
@@ -27,3 +27,7 @@ DunRaider-quickbar-10=Comma seperated list of items in the format of [item=<item
 [step-warning]
 mode=__1__ waited for __2__ ticks
 take=Step: __1__, Action: __2__, Step: __3__ - Take: __4__ __5__
+never idle=[font=default-large-bold]Step __1__ [color=yellow]Never idle warning![/color][/font] character didn't execute any steps for [font=default-large-bold][color=red]__2__[/color][/font] ticks
+keep walking=[font=default-large-bold]Step __1__ [color=yellow]Keep walking warning![/color][/font] character walk, mine or idle for [font=default-large-bold][color=red]__2__[/color][/font] ticks
+keep on path=[font=default-large-bold]Step __1__ [color=yellow]Keep on path warning![/color][/font] character left path for [font=default-large-bold][color=red]__2__[/color][/font] ticks
+keep crafting=[font=default-large-bold]Step __1__ [color=yellow]Keep crafting warning![/color][/font] character didn't handcraft for [font=default-large-bold][color=red]__2__[/color][/font] ticks

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -2591,7 +2591,7 @@
                             <property name="window_name"></property>
                             <property name="window_style">wxBORDER_THEME|wxTAB_TRAVERSAL</property>
                             <object class="wxFlexGridSizer" expanded="0">
-                                <property name="cols">2</property>
+                                <property name="cols">3</property>
                                 <property name="flexible_direction">wxBOTH</property>
                                 <property name="growablecols"></property>
                                 <property name="growablerows"></property>

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -2591,7 +2591,7 @@
                             <property name="window_name"></property>
                             <property name="window_style">wxBORDER_THEME|wxTAB_TRAVERSAL</property>
                             <object class="wxFlexGridSizer" expanded="0">
-                                <property name="cols">3</property>
+                                <property name="cols">2</property>
                                 <property name="flexible_direction">wxBOTH</property>
                                 <property name="growablecols"></property>
                                 <property name="growablerows"></property>
@@ -2600,8 +2600,8 @@
                                 <property name="name">fgSizer4</property>
                                 <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
                                 <property name="permission">none</property>
-                                <property name="rows">4</property>
-                                <property name="vgap">10</property>
+                                <property name="rows">5</property>
+                                <property name="vgap">5</property>
                                 <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxEXPAND</property>
@@ -3288,7 +3288,7 @@
                     </object>
                     <object class="sizeritem" expanded="0">
                         <property name="border">5</property>
-                        <property name="flag">wxEXPAND | wxALL</property>
+                        <property name="flag">wxBOTTOM|wxEXPAND|wxTOP</property>
                         <property name="proportion">1</property>
                         <object class="wxPanel" expanded="0">
                             <property name="BottomDockable">1</property>
@@ -3353,7 +3353,7 @@
                                 <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
                                 <property name="permission">none</property>
                                 <property name="rows">4</property>
-                                <property name="vgap">10</property>
+                                <property name="vgap">5</property>
                                 <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxEXPAND</property>
@@ -4181,8 +4181,8 @@
                                 <property name="name">fgSizer6</property>
                                 <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
                                 <property name="permission">none</property>
-                                <property name="rows">4</property>
-                                <property name="vgap">10</property>
+                                <property name="rows">5</property>
+                                <property name="vgap">5</property>
                                 <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxEXPAND</property>
@@ -4489,6 +4489,270 @@
                                                 <event name="OnRadioButton">OnSaveChosen</event>
                                             </object>
                                         </object>
+                                    </object>
+                                </object>
+                                <object class="sizeritem" expanded="1">
+                                    <property name="border">5</property>
+                                    <property name="flag">wxALL</property>
+                                    <property name="proportion">0</property>
+                                    <object class="wxRadioButton" expanded="1">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer"></property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position"></property>
+                                        <property name="aui_row"></property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">Never Idle</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">rbtn_never_idle</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Toggles that the TAS that it should execute a step in every tick.&#x0A;If it can&apos;t it will raise a warning through the console so you can improve the script.</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="value">0</property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                        <event name="OnRadioButton">OnNeverIdleChosen</event>
+                                    </object>
+                                </object>
+                                <object class="sizeritem" expanded="1">
+                                    <property name="border">5</property>
+                                    <property name="flag">wxALL</property>
+                                    <property name="proportion">0</property>
+                                    <object class="wxRadioButton" expanded="1">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer"></property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position"></property>
+                                        <property name="aui_row"></property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">Keep Walking</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">rbtn_keep_walking</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Toggles that the TAS should never stand still in one spot.&#x0A;If it can&apos;t it will raise a warning through the console so you can improve the script.</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="value">0</property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                        <event name="OnRadioButton">OnKeepWalkingChosen</event>
+                                    </object>
+                                </object>
+                                <object class="sizeritem" expanded="1">
+                                    <property name="border">5</property>
+                                    <property name="flag">wxALL</property>
+                                    <property name="proportion">0</property>
+                                    <object class="wxRadioButton" expanded="1">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer"></property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position"></property>
+                                        <property name="aui_row"></property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">Keep on Path</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">rbtn_keep_on_path</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Toggles that the TAS should stay on pathing, such stone-path or concrete.&#x0A;If it can&apos;t it will raise a warning through the console so you can improve the script.&#x0A;&#x0A;This uses simple detection of: character speed &gt; base speed. So it will be inaccurate if the speed is modified in other ways than tiles.</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="value">0</property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                        <event name="OnRadioButton">OnKeepOnPathChosen</event>
+                                    </object>
+                                </object>
+                                <object class="sizeritem" expanded="1">
+                                    <property name="border">5</property>
+                                    <property name="flag">wxALL</property>
+                                    <property name="proportion">0</property>
+                                    <object class="wxRadioButton" expanded="1">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer"></property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position"></property>
+                                        <property name="aui_row"></property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">Keep Crafting</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">rbtn_keep_crafting</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Toggles that the TAS should keep the handcrafting queued active.&#x0A;If it can&apos;t it will raise a warning through the console so you can improve the script.</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="value">0</property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                        <event name="OnRadioButton">OnKeepCraftingChosen</event>
                                     </object>
                                 </object>
                                 <object class="sizeritem" expanded="1">

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -440,7 +440,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 
 	character_panel = new wxPanel( type_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_THEME|wxTAB_TRAVERSAL );
 	wxFlexGridSizer* fgSizer4;
-	fgSizer4 = new wxFlexGridSizer( 5, 2, 5, 10 );
+	fgSizer4 = new wxFlexGridSizer( 5, 3, 5, 10 );
 	fgSizer4->SetFlexibleDirection( wxBOTH );
 	fgSizer4->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -440,7 +440,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 
 	character_panel = new wxPanel( type_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_THEME|wxTAB_TRAVERSAL );
 	wxFlexGridSizer* fgSizer4;
-	fgSizer4 = new wxFlexGridSizer( 4, 3, 10, 10 );
+	fgSizer4 = new wxFlexGridSizer( 5, 2, 5, 10 );
 	fgSizer4->SetFlexibleDirection( wxBOTH );
 	fgSizer4->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
@@ -546,7 +546,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 
 	building_panel = new wxPanel( type_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_THEME|wxTAB_TRAVERSAL );
 	wxFlexGridSizer* fgSizer5;
-	fgSizer5 = new wxFlexGridSizer( 4, 3, 10, 10 );
+	fgSizer5 = new wxFlexGridSizer( 4, 3, 5, 10 );
 	fgSizer5->SetFlexibleDirection( wxBOTH );
 	fgSizer5->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
@@ -659,11 +659,11 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	building_panel->SetSizer( fgSizer5 );
 	building_panel->Layout();
 	fgSizer5->Fit( building_panel );
-	type_sizer->Add( building_panel, 1, wxEXPAND | wxALL, 5 );
+	type_sizer->Add( building_panel, 1, wxBOTTOM|wxEXPAND|wxTOP, 5 );
 
 	game_panel = new wxPanel( type_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_THEME|wxTAB_TRAVERSAL );
 	wxFlexGridSizer* fgSizer6;
-	fgSizer6 = new wxFlexGridSizer( 4, 2, 10, 10 );
+	fgSizer6 = new wxFlexGridSizer( 5, 2, 5, 10 );
 	fgSizer6->SetFlexibleDirection( wxBOTH );
 	fgSizer6->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
@@ -708,6 +708,26 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 
 
 	fgSizer6->Add( type_sizer_Save, 1, wxEXPAND, 5 );
+
+	rbtn_never_idle = new wxRadioButton( game_panel, wxID_ANY, wxT("Never Idle"), wxDefaultPosition, wxDefaultSize, 0 );
+	rbtn_never_idle->SetToolTip( wxT("Toggles that the TAS that it should execute a step in every tick.\nIf it can't it will raise a warning through the console so you can improve the script.") );
+
+	fgSizer6->Add( rbtn_never_idle, 0, wxALL, 5 );
+
+	rbtn_keep_walking = new wxRadioButton( game_panel, wxID_ANY, wxT("Keep Walking"), wxDefaultPosition, wxDefaultSize, 0 );
+	rbtn_keep_walking->SetToolTip( wxT("Toggles that the TAS should never stand still in one spot.\nIf it can't it will raise a warning through the console so you can improve the script.") );
+
+	fgSizer6->Add( rbtn_keep_walking, 0, wxALL, 5 );
+
+	rbtn_keep_on_path = new wxRadioButton( game_panel, wxID_ANY, wxT("Keep on Path"), wxDefaultPosition, wxDefaultSize, 0 );
+	rbtn_keep_on_path->SetToolTip( wxT("Toggles that the TAS should stay on pathing, such stone-path or concrete.\nIf it can't it will raise a warning through the console so you can improve the script.\n\nThis uses simple detection of: character speed > base speed. So it will be inaccurate if the speed is modified in other ways than tiles.") );
+
+	fgSizer6->Add( rbtn_keep_on_path, 0, wxALL, 5 );
+
+	rbtn_keep_crafting = new wxRadioButton( game_panel, wxID_ANY, wxT("Keep Crafting"), wxDefaultPosition, wxDefaultSize, 0 );
+	rbtn_keep_crafting->SetToolTip( wxT("Toggles that the TAS should keep the handcrafting queued active.\nIf it can't it will raise a warning through the console so you can improve the script.") );
+
+	fgSizer6->Add( rbtn_keep_crafting, 0, wxALL, 5 );
 
 	rbtn_game_panel_hidden = new wxRadioButton( game_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
 	rbtn_game_panel_hidden->SetValue( true );
@@ -1313,6 +1333,10 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	rbtn_pause->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnPauseChosen ), NULL, this );
 	rbtn_stop->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnStopChosen ), NULL, this );
 	rbtn_save->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnSaveChosen ), NULL, this );
+	rbtn_never_idle->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnNeverIdleChosen ), NULL, this );
+	rbtn_keep_walking->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnKeepWalkingChosen ), NULL, this );
+	rbtn_keep_on_path->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnKeepOnPathChosen ), NULL, this );
+	rbtn_keep_crafting->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnKeepCraftingChosen ), NULL, this );
 	modifier_no_order_button->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnNoOrderClicked ), NULL, this );
 	modifier_no_order_button->Connect( wxEVT_RIGHT_UP, wxMouseEventHandler( GUI_Base::OnNoOrderRightClicked ), NULL, this );
 	main_book->Connect( wxEVT_COMMAND_AUINOTEBOOK_PAGE_CHANGED, wxAuiNotebookEventHandler( GUI_Base::OnMainBookPageChanged ), NULL, this );
@@ -1381,6 +1405,10 @@ GUI_Base::~GUI_Base()
 	rbtn_pause->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnPauseChosen ), NULL, this );
 	rbtn_stop->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnStopChosen ), NULL, this );
 	rbtn_save->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnSaveChosen ), NULL, this );
+	rbtn_never_idle->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnNeverIdleChosen ), NULL, this );
+	rbtn_keep_walking->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnKeepWalkingChosen ), NULL, this );
+	rbtn_keep_on_path->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnKeepOnPathChosen ), NULL, this );
+	rbtn_keep_crafting->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnKeepCraftingChosen ), NULL, this );
 	modifier_no_order_button->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnNoOrderClicked ), NULL, this );
 	modifier_no_order_button->Disconnect( wxEVT_RIGHT_UP, wxMouseEventHandler( GUI_Base::OnNoOrderRightClicked ), NULL, this );
 	main_book->Disconnect( wxEVT_COMMAND_AUINOTEBOOK_PAGE_CHANGED, wxAuiNotebookEventHandler( GUI_Base::OnMainBookPageChanged ), NULL, this );

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -112,6 +112,10 @@ class GUI_Base : public wxFrame
 		wxRadioButton* rbtn_pause;
 		wxRadioButton* rbtn_stop;
 		wxRadioButton* rbtn_save;
+		wxRadioButton* rbtn_never_idle;
+		wxRadioButton* rbtn_keep_walking;
+		wxRadioButton* rbtn_keep_on_path;
+		wxRadioButton* rbtn_keep_crafting;
 		wxRadioButton* rbtn_game_panel_hidden;
 		wxPanel* auto_put_panel;
 		wxCheckBox* check_furnace;
@@ -232,6 +236,10 @@ class GUI_Base : public wxFrame
 		virtual void OnPauseChosen( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnStopChosen( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnSaveChosen( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnNeverIdleChosen( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnKeepWalkingChosen( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnKeepOnPathChosen( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnKeepCraftingChosen( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnNoOrderClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnNoOrderRightClicked( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnMainBookPageChanged( wxAuiNotebookEvent& event ) { event.Skip(); }

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -323,6 +323,19 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			case e_idle:
 				idle(currentStep, amount, comment);
 				break;
+
+			case e_never_idle:
+				never_idle(currentStep, comment);
+				break;
+			case e_keep_crafting:
+				keep_crafting(currentStep, comment);
+				break;
+			case e_keep_on_path:
+				keep_on_path(currentStep, comment);
+				break;
+			case e_keep_walking:
+				keep_walking(currentStep, comment);
+				break;
 		}
 	}
 
@@ -896,6 +909,30 @@ void GenerateScript::speed(string step, string speed, string comment)
 void GenerateScript::pause(string step, string comment)
 {
 	step_list += Step(step, "1", "\"pause\"", comment);
+	total_steps += 1;
+}
+
+void GenerateScript::never_idle(string step, string comment)
+{
+	step_list += Step(step, "1", "\"never idle\"", comment);
+	total_steps += 1;
+}
+
+void GenerateScript::keep_walking(string step, string comment)
+{
+	step_list += Step(step, "1", "\"keep walking\"", comment);
+	total_steps += 1;
+}
+
+void GenerateScript::keep_on_path(string step, string comment) 
+{
+	step_list += Step(step, "1", "\"keep on path\"", comment);
+	total_steps += 1;
+}
+
+void GenerateScript::keep_crafting(string step, string comment) 
+{
+	step_list += Step(step, "1", "\"keep crafting\"", comment);
 	total_steps += 1;
 }
 

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -852,7 +852,7 @@ void GenerateScript::mining(string step, string x_cord, string y_cord, string du
 	// Mine the coordinates without checking distance if the user have added Override in the comment - this is mostly useful for removing wreckage. 
 	if (comment == "Override")
 	{
-		step_list += Step(step, "1", "\"mine\", {" + x_cord + ", " + y_cord + "}, " + duration, comment);
+		step_list += Step(step, "1", "\"mine\", {" + x_cord + ", " + y_cord + "}, " + duration, "");
 		total_steps += 1;
 		PaintIntermediateWalk(step, false);
 		return;
@@ -1071,7 +1071,7 @@ void GenerateScript::take(string step, string action, string x_cord, string y_co
 	if (comment == "Override")
 	{
 		item = check_item_name(item);
-		step_list += Step(step, action, "\"take\", {" + x_cord + ", " + y_cord + "}, \"" + item + "\", " + amount + ", " + from, comment);
+		step_list += Step(step, action, "\"take\", {" + x_cord + ", " + y_cord + "}, \"" + item + "\", " + amount + ", " + from, "");
 		total_steps += 1;
 		PaintIntermediateWalk(step, false);
 		return; 
@@ -1109,7 +1109,7 @@ void GenerateScript::put(string step, string action, string x_cord, string y_cor
 	if (comment == "Override")
 	{
 		item = check_item_name(item);
-		step_list += Step(step, action, "\"put\", {" + x_cord + ", " + y_cord + "}, \"" + item + "\", " + amount + ", " + into, comment);
+		step_list += Step(step, action, "\"put\", {" + x_cord + ", " + y_cord + "}, \"" + item + "\", " + amount + ", " + into, "");
 		total_steps += 1;
 		PaintIntermediateWalk(step, false);
 		return;

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -157,6 +157,10 @@ private:
 	void tech(string step, string tech_to_research, string comment);
 	void speed(string step, string speed, string comment);
 	void pause(string step, string comment);
+	void never_idle(string step, string comment);
+	void keep_walking(string step, string comment);
+	void keep_on_path(string step, string comment);
+	void keep_crafting(string step, string comment);
 	void launch(string step, string x_cord, string y_cord, string comment);
 	void save(string step, string nameOfSaveGame);
 	void idle(string step, string amount, string comment);

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -75,7 +75,7 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 		step.Step = Capitalize(segments[0]);
 		step.OriginalX = step.X = size >= 1 && segments[1] != "" ? stod(segments[1]) : 0;
 		step.OriginalY = step.Y = size >= 2 && segments[2] != "" ? stod(segments[2]) : 0;
-		step.Amount = size >= 3 && segments[3] != "" ? to_string(stoi(segments[3])) : "";
+		step.Amount = size >= 3 && segments[3] != "" ? segments[3] == "All" ? "All" : to_string(stoi(segments[3])) : "";
 		step.Item = size >= 4 && segments[4] != "" ? Capitalize(segments[4], true) : "";
 		step.Orientation = size >= 5 && segments[5] != "" ? Capitalize(segments[5]) : "";
 		step.Direction = size >= 6 && segments[6] != "" ? Capitalize(segments[6]) : "";

--- a/src/ParameterChoices.h
+++ b/src/ParameterChoices.h
@@ -36,7 +36,11 @@ const struct parameter_choices_struct
 	const int Pause = comment,
 	stop = comment,
 	save = comment,
-	game_speed = amount | comment;
+	game_speed = amount | comment,
+	never_idle = comment,
+	keep_walking = comment,
+	keep_on_path = comment,
+	keep_crafting = comment;
 
 	//game state interactions
 	const int craft = amount | item | comment,

--- a/src/StepNameToEnum.h
+++ b/src/StepNameToEnum.h
@@ -15,7 +15,9 @@ using std::set;
 /// </summary>
 enum StepType
 {
-	e_stop = 1, e_build, e_craft, e_game_speed, e_pause, e_save, e_recipe, e_limit, e_filter, e_rotate, e_priority, e_put, e_take, e_mine, e_launch, e_walk, e_tech, e_drop, e_pick_up, e_idle, e_cancel_crafting
+	e_stop = 1, e_build, e_craft, e_game_speed, e_pause, e_save, e_recipe, e_limit,
+	e_filter, e_rotate, e_priority, e_put, e_take, e_mine, e_launch, e_walk, e_tech, e_drop, e_pick_up, e_idle, e_cancel_crafting,
+	e_never_idle, e_keep_walking, e_keep_on_path, e_keep_crafting
 };
 
 /// <summary>
@@ -28,7 +30,8 @@ static const vector<string> StepNames{
 	"None", 
 	"Stop", "Build", "Craft", "Game speed", "Pause", "Save",
 	"Recipe", "Limit", "Filter", "Rotate", "Priority", "Put", "Take", "Mine", "Launch",
-	"Walk", "Tech", "Drop", "Pick up", "Idle", "Cancel"
+	"Walk", "Tech", "Drop", "Pick up", "Idle", "Cancel",
+	"Never idle", "Keep walking", "Keep on path", "Keep crafting"
 };
 
 /// <summary>
@@ -36,7 +39,9 @@ static const vector<string> StepNames{
 /// </summary>
 static const map<string, StepType> MapStepNameToStepType = {{"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
 	{"Recipe", e_recipe}, {"Limit", e_limit}, {"Filter", e_filter}, {"Rotate", e_rotate}, {"Priority", e_priority}, {"Put", e_put}, {"Take", e_take}, {"Mine", e_mine}, {"Launch", e_launch},
-	{"Walk", e_walk}, {"Tech", e_tech}, {"Drop", e_drop}, {"Pick up", e_pick_up}, {"Idle", e_idle}, {"Cancel", e_cancel_crafting}};
+	{"Walk", e_walk}, {"Tech", e_tech}, {"Drop", e_drop}, {"Pick up", e_pick_up}, {"Idle", e_idle}, {"Cancel", e_cancel_crafting},
+	{"Never idle", e_never_idle}, {"Keep walking", e_keep_walking}, {"Keep on path", e_keep_on_path}, {"Keep crafting", e_keep_crafting},
+};
 
 StepType ToStepType(string step);
 

--- a/src/StepParameters.cpp
+++ b/src/StepParameters.cpp
@@ -51,7 +51,10 @@ string StepParameters::ToString()
 {
 	switch (StepEnum)
 	{
-
+		case e_never_idle:
+		case e_keep_crafting:
+		case e_keep_on_path:
+		case e_keep_walking:
 		case e_pause:
 		case e_save:
 			return Step + ";" + ";" + ";" + ";" + ";" + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";

--- a/src/TypePanel.cpp
+++ b/src/TypePanel.cpp
@@ -35,7 +35,11 @@ void TypePanel::SetType(wxRadioButton * choosen_btn)
 		parent->rbtn_launch,
 		parent->rbtn_save,
 		parent->rbtn_stop,
-		parent->rbtn_cancel_crafting
+		parent->rbtn_cancel_crafting,
+		parent->rbtn_never_idle,
+		parent->rbtn_keep_walking,
+		parent->rbtn_keep_crafting,
+		parent->rbtn_keep_on_path,
 	};
 	parent->rbtn_character_panel_hidden->SetValue(true);
 	parent->rbtn_building_panel_hidden->SetValue(true);
@@ -92,6 +96,14 @@ void TypePanel::SwitchStep(StepType type)
 		case e_stop: SetType(parent->rbtn_stop);
 			break;
 		case e_cancel_crafting: SetType(parent->rbtn_cancel_crafting);
+			break;
+		case e_never_idle: SetType(parent->rbtn_never_idle);
+			break;
+		case e_keep_crafting: SetType(parent->rbtn_keep_crafting);
+			break;
+		case e_keep_on_path: SetType(parent->rbtn_keep_on_path);
+			break;
+		case e_keep_walking: SetType(parent->rbtn_keep_walking);
 			break;
 		default:
 			// ERROR: You have done something wrong
@@ -193,6 +205,18 @@ string cMain::ExtractStep()
 
 	if (rbtn_cancel_crafting->GetValue())
 		return StepNames[e_cancel_crafting];
+
+	if (rbtn_never_idle->GetValue())
+		return StepNames[e_never_idle];
+
+	if (rbtn_keep_crafting->GetValue())
+		return StepNames[e_keep_crafting];
+
+	if (rbtn_keep_on_path->GetValue())
+		return StepNames[e_keep_on_path];
+
+	if (rbtn_keep_walking->GetValue())
+		return StepNames[e_keep_walking];
 
 	return "not found";
 }
@@ -440,6 +464,38 @@ void cMain::OnGameSpeedChosen(wxCommandEvent& event)
 	type_panel->SetType(rbtn_game_speed);
 	setup_paramters(parameter_choices.game_speed);
 	SetupModifiers(e_game_speed);
+	event.Skip();
+}
+
+void cMain::OnNeverIdleChosen(wxCommandEvent& event)
+{
+	type_panel->SetType(rbtn_never_idle);
+	setup_paramters(parameter_choices.never_idle);
+	SetupModifiers(e_never_idle);
+	event.Skip();
+}
+
+void cMain::OnKeepWalkingChosen(wxCommandEvent& event)
+{
+	type_panel->SetType(rbtn_keep_walking);
+	setup_paramters(parameter_choices.keep_walking);
+	SetupModifiers(e_keep_walking);
+	event.Skip();
+}
+
+void cMain::OnKeepOnPathChosen(wxCommandEvent& event)
+{
+	type_panel->SetType(rbtn_keep_on_path);
+	setup_paramters(parameter_choices.keep_on_path);
+	SetupModifiers(e_keep_on_path);
+	event.Skip();
+}
+
+void cMain::OnKeepCraftingChosen(wxCommandEvent& event)
+{
+	type_panel->SetType(rbtn_keep_crafting);
+	setup_paramters(parameter_choices.keep_crafting);
+	SetupModifiers(e_keep_crafting);
 	event.Skip();
 }
 #pragma endregion

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -493,6 +493,10 @@ void cMain::BackgroundColorUpdate(wxGrid* grid, int row, StepType Step)
 		case e_game_speed:
 		case e_pause:
 		case e_save:
+		case e_keep_crafting:
+		case e_keep_on_path:
+		case e_keep_walking:
+		case e_never_idle:
 			grid->SetCellBackgroundColour(row, 0, *wxYELLOW);
 			return;
 		default:
@@ -1621,6 +1625,26 @@ void cMain::UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event, bool c
 			txt_comment->SetValue(gridEntry->Comment);
 
 			return;
+		case e_never_idle:
+			if (changeType) OnNeverIdleChosen(event);
+			txt_comment->SetValue(gridEntry->Comment);
+
+			return;
+		case e_keep_walking:
+			if (changeType) OnKeepWalkingChosen(event);
+			txt_comment->SetValue(gridEntry->Comment);
+
+			return;
+		case e_keep_crafting:
+			if (changeType) OnKeepCraftingChosen(event);
+			txt_comment->SetValue(gridEntry->Comment);
+
+			return;
+		case e_keep_on_path:
+			if (changeType) OnKeepOnPathChosen(event);
+			txt_comment->SetValue(gridEntry->Comment);
+
+			return;
 		case e_recipe:
 			if (changeType) OnRecipeMenuChosen(event);
 			spin_x->SetValue(gridEntry->X);
@@ -1967,6 +1991,10 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 
 		case e_pause:
 		case e_save:
+		case e_never_idle:
+		case e_keep_crafting:
+		case e_keep_on_path:
+		case e_keep_walking:
 			break;
 
 		case e_game_speed:
@@ -2168,6 +2196,10 @@ bool cMain::ValidateStep(const int& row, StepParameters& stepParameters, bool va
 		case e_idle:
 		case e_drop:
 		case e_cancel_crafting:
+		case e_never_idle:
+		case e_keep_crafting:
+		case e_keep_on_path:
+		case e_keep_walking:
 			return true;
 
 		case e_build:

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -117,6 +117,10 @@ protected:
 	void OnDropChosen(wxCommandEvent& event);
 	void OnPauseChosen(wxCommandEvent& event);
 	void OnStopChosen(wxCommandEvent& event);
+	void OnNeverIdleChosen(wxCommandEvent& event);
+	void OnKeepWalkingChosen(wxCommandEvent& event);
+	void OnKeepOnPathChosen(wxCommandEvent& event);
+	void OnKeepCraftingChosen(wxCommandEvent& event);
 
 	// Modifiers
 	void OnNoOrderClicked(wxCommandEvent& event);


### PR DESCRIPTION
## State modifier warnings 
Added 4 state modifiers that enable specific warnings

![image](https://user-images.githubusercontent.com/18309265/235643856-d77a16ca-f487-4056-a83b-029be4a7689f.png)

### Each is very similar, with the condition that triggers them being the most different.
They are each toggling. So step x enables them, and step x+y disables them.
They are toggled in the pre-tick,
The condition of them is checked in post-tick
They each use the same function to print the warnings to the player

I put the names of them into a table so it is easier to manage.
I also used localized strings for the string messages.

### This is built on #258 