### PR TITLE
Undo and Redo

### DIFF
--- a/src/CommandStack.cpp
+++ b/src/CommandStack.cpp
@@ -3,8 +3,8 @@
 void CommandStack::Push(Command command)
 {
 	buffer[head] = command;
-	hair = head;
 	head = (head + 1) % size;
+	hair = head;
 	tail = head != tail ? tail : (tail + 1) % size;
 }
 

--- a/src/CommandStack.cpp
+++ b/src/CommandStack.cpp
@@ -11,7 +11,7 @@ void CommandStack::Push(Command command)
 Command CommandStack::Pop()
 {
 	if (head == tail) 
-		return {0, NIL, {}, 0};
+		return {0, T_NULL, {}};
 	head = (head + size - 1) % size;
 	return buffer[head];
 }
@@ -19,7 +19,7 @@ Command CommandStack::Pop()
 Command CommandStack::PopBack()
 {
 	if (head == hair)
-		return {0, NIL, {}, 0};
+		return {0, T_NULL, {}};
 	int head_copy = head;
 	head = (head + 1) % size;
 	return buffer[head_copy];

--- a/src/CommandStack.cpp
+++ b/src/CommandStack.cpp
@@ -1,0 +1,26 @@
+#include "CommandStack.h"
+
+void CommandStack::Push(Command command)
+{
+	buffer[head] = command;
+	hair = head;
+	head = (head + 1) % size;
+	tail = head != tail ? tail : (tail + 1) % size;
+}
+
+Command CommandStack::Pop()
+{
+	if (head == tail) 
+		return {0, NIL, {}, 0};
+	head = (head + size - 1) % size;
+	return buffer[head];
+}
+
+Command CommandStack::PopBack()
+{
+	if (head == hair)
+		return {0, NIL, {}, 0};
+	int head_copy = head;
+	head = (head + 1) % size;
+	return buffer[head_copy];
+}

--- a/src/CommandStack.cpp
+++ b/src/CommandStack.cpp
@@ -1,5 +1,12 @@
 #include "CommandStack.h"
 
+void CommandStack::Clear()
+{
+	tail = 0;
+	head = 0;
+	hair = 0;
+}
+
 void CommandStack::Push(Command command)
 {
 	buffer[head] = command;

--- a/src/CommandStack.h
+++ b/src/CommandStack.h
@@ -1,20 +1,25 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <tuple>
+
+#include "StepParameters.h"
 
 using std::vector;
 using std::string;
+using std::tuple;
 
 enum CommandType
 {
-	NIL, ADD, DELETE, MODIFY, MOVE
+	T_NULL, T_ADD, T_DELETE, T_MODIFY, 
+	T_MOVE_UP, T_MOVE_FIVE_UP, T_MOVE_DOWN, T_MOVE_FIVE_DOWN
 };
 struct Command
 {
 	int row;				// The row the action happened at
 	CommandType type;		// The type so it can be reversed
-	vector<string> rows;	// Add should have one string representing a whole row. move should contain 2 rows, one for the current value and one for the new value 
-	int by;					// for move - negative values will be move up
+	// List of modified rows: Tuple of row index and row data
+	vector<tuple<int, StepParameters>> rows;	 
 };
 
 class CommandStack

--- a/src/CommandStack.h
+++ b/src/CommandStack.h
@@ -36,6 +36,7 @@ private:
 public:
 	CommandStack() {}
 
+	void Clear();
 	void Push(Command command);
 	Command Pop();
 	Command PopBack();

--- a/src/CommandStack.h
+++ b/src/CommandStack.h
@@ -16,8 +16,10 @@ enum CommandType
 };
 struct Command
 {
-	int row;				// The row the action happened at
-	CommandType type;		// The type so it can be reversed
+	// The row the action happened at
+	int row;
+	// The type so it can be reversed
+	CommandType type;
 	// List of modified rows: Tuple of row index and row data
 	vector<tuple<int, StepParameters>> rows;	 
 };
@@ -27,8 +29,8 @@ class CommandStack
 	// missing template actions
 
 private:
-	const int size = 32;
-	Command buffer[32] = {};
+	static inline const int size = 32;
+	Command buffer[size] = {};
 	int head = 0, tail = 0, hair = 0;
 
 public:

--- a/src/CommandStack.h
+++ b/src/CommandStack.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <vector>
+#include <string>
+
+using std::vector;
+using std::string;
+
+enum CommandType
+{
+	NIL, ADD, DELETE, MODIFY, MOVE
+};
+struct Command
+{
+	int row;				// The row the action happened at
+	CommandType type;		// The type so it can be reversed
+	vector<string> rows;	// Add should have one string representing a whole row. move should contain 2 rows, one for the current value and one for the new value 
+	int by;					// for move - negative values will be move up
+};
+
+class CommandStack
+{
+	// missing template actions
+
+private:
+	const int size = 32;
+	Command buffer[32] = {};
+	int head = 0, tail = 0, hair = 0;
+
+public:
+	CommandStack() {}
+
+	void Push(Command command);
+	Command Pop();
+	Command PopBack();
+};
+

--- a/src/Factorio-TAS-Generator.vcxproj
+++ b/src/Factorio-TAS-Generator.vcxproj
@@ -165,6 +165,7 @@
     <ClCompile Include="BuildingNameToIndex.cpp" />
     <ClCompile Include="cApp.cpp" />
     <ClCompile Include="cMain.cpp" />
+    <ClCompile Include="CommandStack.cpp" />
     <ClCompile Include="DialogProgressBar.cpp" />
     <ClCompile Include="Functions.cpp" />
     <ClCompile Include="GenerateScript.cpp" />
@@ -183,6 +184,7 @@
     <ClInclude Include="BuildingNameToIndex.h" />
     <ClInclude Include="cApp.h" />
     <ClInclude Include="cMain.h" />
+    <ClInclude Include="CommandStack.h" />
     <ClInclude Include="Functions.h" />
     <ClInclude Include="GenerateScript.h" />
     <ClInclude Include="GUI_Base.h" />

--- a/src/Factorio-TAS-Generator.vcxproj.filters
+++ b/src/Factorio-TAS-Generator.vcxproj.filters
@@ -24,6 +24,7 @@
     </ClCompile>
     <ClCompile Include="ShortcutChanger.cpp" />
     <ClCompile Include="ImportStepsPanel.cpp" />
+    <ClCompile Include="CommandStack.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cApp.h" />
@@ -68,6 +69,7 @@
     <ClInclude Include="Orientation.h" />
     <ClInclude Include="Priority.h" />
     <ClInclude Include="TasFileConstants.h" />
+    <ClInclude Include="CommandStack.h" />
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\Lua Files\control.lua">

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -483,7 +483,7 @@
                         <property name="label">Save</property>
                         <property name="name">shortcut_Save</property>
                         <property name="permission">none</property>
-                        <property name="shortcut">Alt+Q</property>
+                        <property name="shortcut">Ctrl+S</property>
                         <property name="unchecked_bitmap"></property>
                         <event name="OnMenuSelection">OnSaveMenuSelected</event>
                     </object>
@@ -5582,7 +5582,7 @@
                                         <property name="border">5</property>
                                         <property name="flag">wxALL</property>
                                         <property name="proportion">0</property>
-                                <object class="wxCheckBox" expanded="1">
+                                        <object class="wxCheckBox" expanded="1">
                                             <property name="BottomDockable">1</property>
                                             <property name="LeftDockable">1</property>
                                             <property name="RightDockable">1</property>

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -483,7 +483,7 @@
                         <property name="label">Save</property>
                         <property name="name">shortcut_Save</property>
                         <property name="permission">none</property>
-                        <property name="shortcut">Ctrl+S</property>
+                        <property name="shortcut">Alt+Q</property>
                         <property name="unchecked_bitmap"></property>
                         <event name="OnMenuSelection">OnSaveMenuSelected</event>
                     </object>
@@ -5582,7 +5582,7 @@
                                         <property name="border">5</property>
                                         <property name="flag">wxALL</property>
                                         <property name="proportion">0</property>
-                                        <object class="wxCheckBox" expanded="1">
+                                <object class="wxCheckBox" expanded="1">
                                             <property name="BottomDockable">1</property>
                                             <property name="LeftDockable">1</property>
                                             <property name="RightDockable">1</property>

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -59,7 +59,7 @@
             <property name="window_style">wxTAB_TRAVERSAL</property>
             <property name="xrc_skip_sizer">1</property>
             <event name="OnClose">OnApplicationClose</event>
-            <object class="wxMenuBar" expanded="0">
+            <object class="wxMenuBar" expanded="1">
                 <property name="bg"></property>
                 <property name="context_help"></property>
                 <property name="context_menu">1</property>
@@ -203,7 +203,7 @@
                         <event name="OnMenuSelection">OnOnlyGenerateSteps</event>
                     </object>
                 </object>
-                <object class="wxMenu" expanded="0">
+                <object class="wxMenu" expanded="1">
                     <property name="label">Shortcuts</property>
                     <property name="name">menu_shortcuts</property>
                     <property name="permission">protected</property>
@@ -584,6 +584,34 @@
                         <property name="shortcut">Shift+1</property>
                         <property name="unchecked_bitmap"></property>
                         <event name="OnMenuSelection">OnCancelCraftingMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Undo</property>
+                        <property name="name">shortcut_undo</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Ctrl+Z</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnUndoMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Redo</property>
+                        <property name="name">shortcut_redo</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Ctrl+Y</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnRedoMenuSelected</event>
                     </object>
                 </object>
                 <object class="wxMenu" expanded="0">

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -132,7 +132,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	menu_shortcuts->Append( shortcut_launch );
 
 	wxMenuItem* shortcut_Save;
-	shortcut_Save = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Save") ) + wxT('\t') + wxT("Alt+Q"), wxEmptyString, wxITEM_NORMAL );
+	shortcut_Save = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Save") ) + wxT('\t') + wxT("Ctrl+S"), wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_Save );
 
 	wxMenuItem* shortcut_pause;

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -132,7 +132,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	menu_shortcuts->Append( shortcut_launch );
 
 	wxMenuItem* shortcut_Save;
-	shortcut_Save = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Save") ) + wxT('\t') + wxT("Ctrl+S"), wxEmptyString, wxITEM_NORMAL );
+	shortcut_Save = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Save") ) + wxT('\t') + wxT("Alt+Q"), wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_Save );
 
 	wxMenuItem* shortcut_pause;

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -163,6 +163,14 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	shortcut_cancel_crafting = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Cancel Crafting") ) + wxT('\t') + wxT("Shift+1"), wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_cancel_crafting );
 
+	wxMenuItem* shortcut_undo;
+	shortcut_undo = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Undo") ) + wxT('\t') + wxT("Ctrl+Z"), wxEmptyString, wxITEM_NORMAL );
+	menu_shortcuts->Append( shortcut_undo );
+
+	wxMenuItem* shortcut_redo;
+	shortcut_redo = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Redo") ) + wxT('\t') + wxT("Ctrl+Y"), wxEmptyString, wxITEM_NORMAL );
+	menu_shortcuts->Append( shortcut_redo );
+
 	main_menubar->Append( menu_shortcuts, wxT("Shortcuts") );
 
 	menu_goals = new wxMenu();
@@ -1355,6 +1363,8 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMoveUpMenuSelected ), this, shortcut_move_up->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMoveDownMenuSelected ), this, shortcut_move_down->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnCancelCraftingMenuSelected ), this, shortcut_cancel_crafting->GetId());
+	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnUndoMenuSelected ), this, shortcut_undo->GetId());
+	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnRedoMenuSelected ), this, shortcut_redo->GetId());
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuSteelAxeClicked ), this, goal_steelaxe->GetId());
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuGOTLAPClicked ), this, goal_GOTLAP->GetId());
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuAnyPercentClicked ), this, goal_any_percent->GetId());

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -214,6 +214,8 @@ class GUI_Base : public wxFrame
 		virtual void OnMoveUpMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMoveDownMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCancelCraftingMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnUndoMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnRedoMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuSteelAxeClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuGOTLAPClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuAnyPercentClicked( wxCommandEvent& event ) { event.Skip(); }

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -2907,5 +2907,50 @@ void cMain::OnUndoMenuSelected(wxCommandEvent& event)
 void cMain::OnRedoMenuSelected(wxCommandEvent& event)
 {
 	Command command = stack.PopBack();
+
+	switch (command.type)
+	{
+		case T_NULL:
+			break;
+		case T_ADD:
+			{
+				for (auto& [row, step] : command.rows)
+				{
+					AddStep(row, step);
+				}
+			}
+			break;
+		case T_DELETE:
+			{
+				wxArrayInt rows{};
+				for (auto& [row, _] : command.rows)
+				{
+					rows.Add(row);
+				}
+				DeleteSteps(rows, true);
+			}
+			break;
+		case T_MODIFY:
+			{
+				auto& [row, param] = command.rows[1];
+				ChangeStep(command.row, param);
+			}
+			break;
+		case T_MOVE_UP:
+			{
+				SelectRowsInGrid(command.rows);
+				MoveRow(grid_steps, true);
+			}
+			break;
+		case T_MOVE_DOWN:
+			{
+				SelectRowsInGrid(command.rows);
+				MoveRow(grid_steps, false);
+			}
+			break;
+
+		default:
+			break;
+	}
 }
 

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -810,25 +810,25 @@ vector< tuple<int, StepParameters>> cMain::DeleteSteps(wxArrayInt steps, bool au
 	return_list.reserve(steps.size());
 	return_list.push_back({steps[0], StepGridData.at(steps[0])});
 
-	vector<pair<int, int>> blocks{
-		{steps[0], 1}
-	};
-	pair<int, int>* current_block = &blocks[0];
+	
+	pair<int, int> current_block = {steps[0], 1};
+	vector<pair<int, int>> blocks{};
 	blocks.reserve(steps.size());
 	for (int i = 1; i < steps.size(); i++)
 	{
 		return_list.push_back({steps[i], StepGridData.at(steps[i])});
-
-		if (steps[i] == current_block->first + current_block->second + 1)
+		int block_size = current_block.first + current_block.second;
+		if (steps[i] == block_size)
 		{
-			current_block->second += 1;
+			current_block.second = current_block.second + 1;
 		}
 		else
 		{
-			blocks.push_back({steps[i], 1});
-			current_block++;
+			blocks.push_back(current_block);
+			current_block = {steps[i], 1};
 		}
 	}
+	blocks.push_back(current_block);
 
 	for (auto it = blocks.rbegin(); it != blocks.rend(); ++it)
 	{

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -846,6 +846,7 @@ vector< tuple<int, StepParameters>> cMain::DeleteSteps(wxArrayInt steps, bool au
 
 		StepGridData.erase(iStart, iEnd);
 	}
+
 	return return_list;
 }
 
@@ -2847,9 +2848,9 @@ void cMain::OnSkipClicked(wxCommandEvent& event)
 void cMain::SelectRowsInGrid(vector<tuple<int, StepParameters>> rows)
 {
 	grid_steps->ClearSelection();
-	for (auto& [row, _] : rows)
+	for (auto& [index, data] : rows)
 	{
-		grid_steps->SelectRow(row, true);
+		grid_steps->SelectRow(index, true);
 	}
 }
 

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -200,6 +200,8 @@ void cMain::ResetToNewWindow()
 	}
 
 	SetLabel(window_title);
+
+	stack.Clear();
 }
 
 bool cMain::CheckBeforeClose()
@@ -844,7 +846,7 @@ vector< tuple<int, StepParameters>> cMain::DeleteSteps(wxArrayInt steps, bool au
 
 		StepGridData.erase(iStart, iEnd);
 	}
-	return_list;
+	return return_list;
 }
 
 tuple<int, StepParameters> cMain::GetRowTuple(int index)
@@ -2278,17 +2280,9 @@ void cMain::UpdateStepGrid(int row, StepParameters* stepParameters)
 
 	PopulateGrid(grid_steps, row, &gridEntry);
 
-	if (grid_steps->IsSelection())
-	{
-		auto it1 = StepGridData.begin();
-		it1 += row;
-
-		StepGridData.insert(it1, *stepParameters);
-	}
-	else
-	{
-		StepGridData.push_back(*stepParameters);
-	}
+	auto it1 = StepGridData.begin();
+	it1 += row;
+	StepGridData.insert(it1, *stepParameters);
 
 	BackgroundColorUpdate(grid_steps, row, stepParameters->StepEnum);
 }
@@ -2853,9 +2847,9 @@ void cMain::OnSkipClicked(wxCommandEvent& event)
 void cMain::SelectRowsInGrid(vector<tuple<int, StepParameters>> rows)
 {
 	grid_steps->ClearSelection();
-	for (auto& [r, _] : rows)
+	for (auto& [row, _] : rows)
 	{
-		grid_steps->SelectRow(r, true);
+		grid_steps->SelectRow(row, true);
 	}
 }
 
@@ -2908,6 +2902,7 @@ void cMain::OnUndoMenuSelected(wxCommandEvent& event)
 			break;
 	}
 }
+
 void cMain::OnRedoMenuSelected(wxCommandEvent& event)
 {
 	Command command = stack.PopBack();

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -34,6 +34,7 @@
 #include "TasFileConstants.h"
 
 #include "../icon.xpm"
+#include "CommandStack.h"
 
 using std::string;
 using std::vector;
@@ -218,6 +219,14 @@ private:
 
 	map<string, vector<StepParameters>> template_map;
 
+	// Undo and redo
+	void OnUndoMenuSelected(wxCommandEvent& event);
+	void OnRedoMenuSelected(wxCommandEvent& event);
+	CommandStack stack;
+	vector<tuple<int, StepParameters>> GetSelectedRowTuples();
+	tuple<int, StepParameters> GetRowTuple(int index);
+	void SelectRowsInGrid(vector<tuple<int, StepParameters>> rows);
+
 	void ResetToNewWindow();
 	bool ChecksBeforeResetWindow();
 	bool CheckBeforeClose();
@@ -253,7 +262,9 @@ private:
 	int GenerateBuildingSnapShot(int end_row);
 	void PopulateStepGrid();
 
-	void AddStep(int row);
+	vector<tuple<int, StepParameters>> AddStep(int row, StepParameters step);
+	vector< tuple<int, StepParameters>> ChangeStep(int row, StepParameters stepParameters);
+	vector< tuple<int, StepParameters>> DeleteSteps(wxArrayInt steps, bool auto_confirm = false);
 	void GridTransfer(wxGrid* from, const int& fromRow, wxGrid* to, const int& toRow);
 	GridEntry ExtractGridEntry(wxGrid* grid, const int& row);
 

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -262,7 +262,7 @@ private:
 	int GenerateBuildingSnapShot(int end_row);
 	void PopulateStepGrid();
 
-	vector<tuple<int, StepParameters>> AddStep(int row, StepParameters step);
+	vector<tuple<int, StepParameters>> AddStep(int row, StepParameters step, bool auto_put = true);
 	vector< tuple<int, StepParameters>> ChangeStep(int row, StepParameters stepParameters);
 	vector< tuple<int, StepParameters>> DeleteSteps(wxArrayInt steps, bool auto_confirm = false);
 	void GridTransfer(wxGrid* from, const int& fromRow, wxGrid* to, const int& toRow);


### PR DESCRIPTION
This adds the option to Ctrl+Z to undo and Ctrl+Y to redo a few types of actions.

It is built State modifiers, so there are some unrelated commits included.

The change can be broken into 4 categories:
1. Undo and Redo has been added to the shortcut menu
2. Command stack, class has been added
3. Undo and Redo handlers has been added the can reverse the user actions
4. The clickhandlers for the commands have been modified to fit into the undo and redo handlers

### Command stack
The command stack is a custom circular buffer that can handle 32 elements. In such a way that overflow overrides old elements. However it is also possible to pop items of the stack (REDO) and further it is possible to pop_back items (UNDO) reusing the items on it.

### Not included
This only observes ADD, DELETE, CHANGE, MOVE UP, and MOVE DOWN for the steps grid.
Which means MOVE 5, import steps, colouring, no-order modifier, everything template, etc. Is not included.