### PR TITLE
Changed Goal and Log level

### DIFF
--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -1,9 +1,9 @@
 local util = require("util")
 local crash_site = require("crash-site")
-
-local tas_generator = require("steps")
-local steps = tas_generator.steps
-local debug_state = require("goal")
+require("goals")
+local tas_generator = require("variables")
+local steps = require("steps")
+local debug_state = true
 local run = true
 local never_stop = false
 local use_all_ticks = false
@@ -114,15 +114,27 @@ local on_player_created = function(event)
     player.get_main_inventory().sort_and_merge()
 end
 
---Print message intended for viewers
-local function msg(msg)
-    player.print(msg)
+---Print message intended for viewers
+---@param message LocalisedString
+---@param color Color | nil
+local function Message(message, color)
+    player.print(message, color or {})
 end
 
---Print debug message about what the tas is doing
-local function debug(msg, supress_info)
-	if debug_state then
-		player.print(msg)
+---Print commment message intended for viewers
+---@param message LocalisedString | nil
+local function Comment(message)
+	if PRINT_COMMENT and message and message ~= "" then
+		player.print(message)
+	end
+end
+
+---Print Debug message about what the tas is doing
+---@param message LocalisedString
+---@param supress_info boolean? Includes extra information in message
+local function Debug(message, supress_info)
+	if LOGLEVEL == 0 then
+		player.print(message)
         if not supress_info then
 			player.print(string.format(
 				"Seconds: %s, tick: %s, player position [%d, %d]",
@@ -135,23 +147,35 @@ local function debug(msg, supress_info)
 	end
 end
 
---Print warning in case of errors in tas programming
-local function warning(msg)
-    if debug_state then
+---Print warning in case of errors in tas programming
+---@param message LocalisedString
+---@param color Color | nil Message color or default yellow
+local function Warning(message, color)
+    if LOGLEVEL < 2 then
 		global.warning_mode = global.warning_mode or {start = game.tick}
-		player.print(msg, {r=1, g=1}) -- print warnings in yellow
+		player.print(message, color or {r=1, g=1,})
+	end
+end
+
+---Print warning in case of errors in tas programming
+---@param message LocalisedString
+---@param color Color | nil Message color or default red
+local function Error(message, color)
+    if LOGLEVEL < 3 then
+		global.warning_mode = global.warning_mode or {start = game.tick}
+		player.print(message, color or {r=1,})
 	end
 end
 
 local function end_warning_mode(msg)
-	if debug_state and global.warning_mode then
+	if global.warning_mode then
 		player.print({"step-warning.mode", msg, game.tick - global.warning_mode.start,}, {r=1, g=1}) -- print warnings in yellow
 		global.warning_mode = nil
 	end
 end
 
 local function end_never_stop_modifier_warning_mode()
-	if debug_state and global.never_stop_modifier_warning_mode then
+	if global.never_stop_modifier_warning_mode then
 		player.print(string.format("Step: %d - The character stood stil for %d tick(s) ", global.never_stop_modifier_warning_mode.step, game.tick - global.never_stop_modifier_warning_mode.start),{r=1, g=1})
 		global.never_stop_modifier_warning_mode = nil
 	end
@@ -159,7 +183,7 @@ end
 
 -- I think it should be possible to do something like looping through the different types and check if any are tagged for termination
 local function end_use_all_ticks_warning_mode()
-	if debug_state and global.use_all_ticks_warning_mode then
+	if global.use_all_ticks_warning_mode then
 		player.print(string.format("Step: %d - %d tick(s) not used", global.use_all_ticks_warning_mode.step, game.tick - global.use_all_ticks_warning_mode.start), {r=1, g=1})
 		global.use_all_ticks_warning_mode = nil
 	end
@@ -173,7 +197,7 @@ local warnings = {
 }
 
 local function end_state_warning_mode(warning, extra)
-	if debug_state and global[warning] then
+	if global[warning] then
 		game.print(
 			{"step-warning."..warning, steps[global[warning].step][1][1], game.tick - global[warning].start, extra}
 		)
@@ -199,12 +223,12 @@ end
 local function save(task, nameOfSaveGame)
 	save_global()
 	if game.is_multiplayer() then
-		debug(string.format("Step: %s, saving game as %s", task, nameOfSaveGame))
+		if PRINT_SAVEGAME then Debug(string.format("Step: %s, saving game as %s", task, nameOfSaveGame)) end
 		game.server_save(nameOfSaveGame)
 		return true
 	end
 
-	debug(string.format("Step: %s, saving game as _autosave-%s", task, nameOfSaveGame))
+	if PRINT_SAVEGAME then Debug(string.format("Step: %s, saving game as _autosave-%s", task, nameOfSaveGame)) end
 	game.auto_save(nameOfSaveGame)
 	return true;
 end
@@ -220,7 +244,7 @@ local function check_selection_reach()
 
 	if not player_selection then
 		if not walking.walking then
-			warning(string.format("Step: %s, Action: %s, Step: %d - %s: Cannot select entity", task[1], task[2], step, task_category))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - %s: Cannot select entity", task[1], task[2], step, task_category))
 		end
 
 		return false
@@ -228,7 +252,7 @@ local function check_selection_reach()
 
 	if not player.can_reach_entity(player_selection) then
 		if not walking.walking then
-			warning(string.format("Step: %s, Action: %s, Step: %d - %s: Cannot reach entity", task[1], task[2], step, task_category))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - %s: Cannot reach entity", task[1], task[2], step, task_category))
 		end
 
 		return false
@@ -243,7 +267,7 @@ local function check_inventory()
 
 	if not target_inventory then
 		if not walking.walking then
-			warning(string.format("Step: %s, Action: %s, Step: %d - %s: Cannot get entity inventory", task[1], task[2], step, task_category))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - %s: Cannot get entity inventory", task[1], task[2], step, task_category))
 		end
 
 		return false
@@ -272,7 +296,7 @@ local function put()
 
 	if removalable_items == 0 then
 		if not walking.walking then
-			warning(string.format("Step: %s, Action: %s, Step: %d - Put: %s is not available in your inventory", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - Put: %s is not available in your inventory", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 		end
 
 		return false;
@@ -280,7 +304,7 @@ local function put()
 
 	if insertable_items == 0 then
 		if not walking.walking then
-			warning(string.format("Step: %s, Action: %s, Step: %d - Put: %s can't be put into target inventory", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - Put: %s can't be put into target inventory", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 		end
 
 		return false;
@@ -288,7 +312,7 @@ local function put()
 
 	if amount > removalable_items or amount > insertable_items then
 		if not walking.walking then
-			warning(string.format("Step: %s, Action: %s, Step: %d - Put: not enough %s can be transferred. Amount: %d Removalable: %d Insertable: %d", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), amount, removalable_items, insertable_items))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - Put: not enough %s can be transferred. Amount: %d Removalable: %d Insertable: %d", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), amount, removalable_items, insertable_items))
 		end
 
 		return false
@@ -307,7 +331,7 @@ local function put()
 	}
 
 	if amount < 1 then
-		warning(string.format("Step: %s, Action: %s, Step: %d - Put: %s can not be transferred. Amount: %d Removalable: %d Insertable: %d", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), amount, removalable_items, insertable_items))
+		Warning(string.format("Step: %s, Action: %s, Step: %d - Put: %s can not be transferred. Amount: %d Removalable: %d Insertable: %d", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), amount, removalable_items, insertable_items))
 		return false
 	end
 
@@ -348,7 +372,7 @@ local function take()
 
 	if removalable_items == 0 then
 		if not walking.walking then
-			warning({"step-warning.take", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), "is not available from the inventory"})
+			Warning({"step-warning.take", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), "is not available from the inventory"})
 		end
 
 		return false;
@@ -356,7 +380,7 @@ local function take()
 
 	if insertable_items == 0 then
 		if not walking.walking then
-			warning(string.format("Step: %s, Action: %s, Step: %d - Take: %s can't be put into your inventory", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - Take: %s can't be put into your inventory", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 		end
 
 		return false;
@@ -364,7 +388,7 @@ local function take()
 
 	if amount > removalable_items or amount > insertable_items then
 		if not walking.walking then
-			warning(string.format("Step: %s, Action: %s, Step: %d - Take: not enough %s can be transferred. Amount: %d Removalable: %d Insertable: %d", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), amount, removalable_items, insertable_items))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - Take: not enough %s can be transferred. Amount: %d Removalable: %d Insertable: %d", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), amount, removalable_items, insertable_items))
 		end
 
 		return false
@@ -397,7 +421,7 @@ end
 local function craft()
 	if not player.force.recipes[item].enabled then
 		if(step > step_reached) then
-			warning(string.format("Step: %s, Action: %s, Step: %d - Craft: It is not possible to craft %s - It needs to be researched first.", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - Craft: It is not possible to craft %s - It needs to be researched first.", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 			step_reached = step
 		end
 
@@ -408,7 +432,7 @@ local function craft()
 		player.cancel_crafting{ index = 1, count = 1000000}
 		return false
 	elseif global.wait_for_recipe and player.crafting_queue_size > 0 then
-		warning(string.format("Step: %s, Action: %s, Step: %d - Craft [item=%s]: It is not possible to craft as the queue is not empty", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+		Warning(string.format("Step: %s, Action: %s, Step: %d - Craft [item=%s]: It is not possible to craft as the queue is not empty", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 		step_reached = step
 		return false
 	else
@@ -425,7 +449,7 @@ local function craft()
 			player.begin_crafting{count = count, recipe = item}
 		else
 			if not walking.walking then
-				warning(string.format("Step: %s, Action: %s, Step: %d - Craft: It is not possible to craft %s - Only possible to craft %d of %d", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), amount, count))
+				Warning(string.format("Step: %s, Action: %s, Step: %d - Craft: It is not possible to craft %s - Only possible to craft %d of %d", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper), amount, count))
 			end
 
 			return false
@@ -434,7 +458,7 @@ local function craft()
 		return true
     else
         if(step > step_reached) then
-            warning(string.format("Step: %s, Action: %s, Step: %d - Craft: It is not possible to craft %s - Please check the script", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+            Warning(string.format("Step: %s, Action: %s, Step: %d - Craft: It is not possible to craft %s - Please check the script", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
             step_reached = step
 		end
 
@@ -457,12 +481,12 @@ local function cancel_crafting()
 				end_warning_mode(string.format("Step: %s, Action: %s, Step: %d - Cancel: [item=%s]", task[1], task[2], step, item ))
 				return true
 			else
-				warning(string.format("Step: %s, Action: %s, Step: %d - Cancel craft: It is not possible to cancel %s - Please check the script", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+				Warning(string.format("Step: %s, Action: %s, Step: %d - Cancel craft: It is not possible to cancel %s - Please check the script", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 				return false
 			end
 		end
 	end
-	warning(string.format("Step: %s, Action: %s, Step: %d - Cancel craft: It is not possible to cancel %s - Please check the script", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+	Warning(string.format("Step: %s, Action: %s, Step: %d - Cancel craft: It is not possible to cancel %s - Please check the script", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 	return false
 end
 
@@ -574,7 +598,7 @@ local function build()
 	if player.get_item_count(item) == 0 then
 		if(step > step_reached) then
 			if walking.walking == false then
-				warning(string.format("Step: %s, Action: %s, Step: %d - Build: %s not available", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+				Warning(string.format("Step: %s, Action: %s, Step: %d - Build: %s not available", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 				step_reached = step
 			end
 		end
@@ -604,7 +628,7 @@ local function build()
 				return true
 
 			elseif not walking.walking then
-				warning(string.format("Step: %s, Action: %s, Step: %d - Build: %s not in reach", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+				Warning(string.format("Step: %s, Action: %s, Step: %d - Build: %s not in reach", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 			end
 
 			return false
@@ -612,9 +636,9 @@ local function build()
 		elseif player.can_place_entity{name = item, position = target_position, direction = direction} then
 			end_warning_mode(string.format("Step: %s, Action: %s, Step: %d - Build: [item=%s]", task[1], task[2], step, item ))
 			return create_entity_replace()
-		else 
+		else
 			if not walking.walking then
-				warning(string.format("Step: %s, Action: %s, Step: %d - Build: %s cannot be placed", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+				Warning(string.format("Step: %s, Action: %s, Step: %d - Build: %s cannot be placed", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 			end
 
 			return false
@@ -637,7 +661,7 @@ local function build()
 
 		else
 			if not walking.walking then
-				warning(string.format("Step: %s, Action: %s, Step: %d - Build: %s cannot be placed", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+				Warning(string.format("Step: %s, Action: %s, Step: %d - Build: %s cannot be placed", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 			end
 
 			return false
@@ -942,7 +966,7 @@ local function recipe()
 
 	if not player.force.recipes[item].enabled then
 		if(step > step_reached) then
-			warning(string.format("Step: %s, Action: %s, Step: %d - Recipe: It is not possible to set recipe %s - It needs to be researched first.", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - Recipe: It is not possible to set recipe %s - It needs to be researched first.", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 			step_reached = step
 		end
 
@@ -950,7 +974,7 @@ local function recipe()
 	end
 
 	if global.wait_for_recipe and player_selection.crafting_progress ~= 0 then
-		warning(string.format("Step: %s, Action: %s, Step: %d - Set recipe %s: The entity is still crafting.", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+		Warning(string.format("Step: %s, Action: %s, Step: %d - Set recipe %s: The entity is still crafting.", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
 		step_reached = step
 		return false
 	end
@@ -977,12 +1001,12 @@ local function tech()
 	if steps[step].comment and steps[step].comment == "Cancel" and player.force.current_research then
 		player.force.research_queue = {}
 		player.force.add_research(item)
-		msg(string.format("Research: Cleared queue and %s added", item))
+		if PRINT_TECH then Message(string.format("Research: Cleared queue and %s added", item)) end
 		return true
 	end
 
 	local was_addded = player.force.add_research(item)
-	msg(string.format("Research: %s%s added", item, was_addded and "" or " not"))
+	if PRINT_TECH then Message(string.format("Research: %s%s added", item, was_addded and "" or " not")) end
 	return true
 end
 
@@ -995,7 +1019,7 @@ end
 -- Set the gameplay speed. 1 is standard speed
 local function speed(speed)
 	game.speed = speed
-    msg(string.format("Changed game speed to %s", speed))
+    Message(string.format("Changed game speed to %s", speed))
 	return true
 end
 
@@ -1099,7 +1123,7 @@ local function shoot()
 		player.shooting_state = {state = defines.shooting.shooting_selected, position = target_position}
 		global.tas_shooting_amount = global.tas_shooting_amount - 1
 	else
-		warning(string.format("Step: %s, Action: %s, Step: %d - Shoot: %d can't shoot location", task[1], task[2], step, amount ))
+		Warning(string.format("Step: %s, Action: %s, Step: %d - Shoot: %d can't shoot location", task[1], task[2], step, amount ))
 	end
 
 	if global.tas_shooting_amount == 0 then
@@ -1118,29 +1142,29 @@ local function throw()
 	if player.get_item_count (item) > 0 then
 		local stack, index = player.get_main_inventory().find_item_stack(item)
 		if not stack or not index then
-			warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] can't find item in player inventory", task[1], task[2], step, item ))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] can't find item in player inventory", task[1], task[2], step, item ))
 			return false
 		end
 
 		local prototype = stack.prototype
 		if not prototype.capsule_action then 
-			warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] is not a throwable type", task[1], task[2], step, item ))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] is not a throwable type", task[1], task[2], step, item ))
 		end
 		if prototype.capsule_action.type ~= "throw" then 
-			warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] is not a throwable type", task[1], task[2], step, item ))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] is not a throwable type", task[1], task[2], step, item ))
 		end
 		local dist = math.sqrt(
 			math.abs(player.position.x - target_position[1])^2 + math.abs(player.position.y - target_position[2])^2
 		)
 		local can_reach = prototype.capsule_action.attack_parameters.range > dist and dist > prototype.capsule_action.attack_parameters.min_range
 		if not can_reach then
-			warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] target is out of range", task[1], task[2], step, item ))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] target is out of range", task[1], task[2], step, item ))
 			return false
 		end
 
 		global.tas_throw_cooldown = global.tas_throw_cooldown or 0
 		if game.tick < global.tas_throw_cooldown then
-			warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] is still on cooldown", task[1], task[2], step, item ))
+			Warning(string.format("Step: %s, Action: %s, Step: %d - throw: [item=%s] is still on cooldown", task[1], task[2], step, item ))
 			return false
 		end
 
@@ -1295,7 +1319,7 @@ local original_warning = warning
 local function load_StepBlock()
 	if global.step_block or not steps[step].no_order then return end
 	global.step_block = {}
-	debug("entering step block")
+	Debug("entering step block")
 	warning = function ()
 		--override warning with a function that does nothing
 	end
@@ -1320,7 +1344,7 @@ local function execute_StepBlock()
 		_step = steps[_step_index]
 		_success = doStep(_step)
 		if _success then
-			debug(string.format("Executed %d - Type: %s, Step: %d", _step[1][1], _step[2]:gsub("^%l", string.upper), _step_index), true)
+			Debug(string.format("Executed %d - Type: %s, Step: %d", _step[1][1], _step[2]:gsub("^%l", string.upper), _step_index), true)
 			table.remove(global.step_block, i)
 			break
 		end
@@ -1330,11 +1354,10 @@ local function execute_StepBlock()
 		global.step_block = nil
 		global.step_block_info = nil
 		warning = original_warning
-		debug("Ending step block")
+		Debug("Ending step block")
 	elseif (game.tick - global.step_block_info.start_tick) > (25 * global.step_block_info.total_steps) then
-		debug_state = true
 		warning = original_warning
-		warning("Catastrofic execution of [color=red]No order[/color] step block. Exceeeded ".. (25 * global.step_block_info.total_steps) .. " ticks.")
+		Error("Catastrofic execution of No order step block. Exceeeded ".. (25 * global.step_block_info.total_steps) .. " ticks.")
 		run = false
 	end
 end
@@ -1344,28 +1367,29 @@ local function handle_pretick()
 	global.state = global.state or {}
 	while run do
 		if steps[step] == nil then
-			debug_state = false
 			run = false
 			return
 		elseif (steps[step][2] == "speed") then
-			if steps[step].comment then msg(steps[step].comment) end
-			debug(string.format("Step: %s, Action: %s, Step: %s - Game speed: %d", steps[step][1][1], steps[step][1][2], step, steps[step][3]))
+			Comment(steps[step].comment)
+			Debug(string.format("Step: %s, Action: %s, Step: %s - Game speed: %d", steps[step][1][1], steps[step][1][2], step, steps[step][3]))
 			speed(steps[step][3])
 			step = step + 1
 		elseif steps[step][2] == "save" then
 			queued_save = {name = steps[step][1][1], step = steps[step][3]}
 			step = step + 1
 		elseif steps[step][2] == "pick" then
-			if steps[step].comment then msg(steps[step].comment) end
+			Comment(steps[step].comment)
+			if pickup_ticks and pickup_ticks > 0 then 
+				Debug(string.format("Previous pickup not completed with %d ticks left before adding %d extra.", pickup_ticks, steps[step][3])) 
+			end
 			pickup_ticks = pickup_ticks + steps[step][3] - 1
 			player.picking_state = true
-			change_step(1)
+			step = step + 1
 		elseif (steps[step][2] == "pause") then
 			pause()
-			msg("Script paused")
-			msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
+			Message("Script paused")
+			Debug(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
 			change_step(1)
-			debug_state = false
 		elseif(steps[step][2] == "walk" and (walking.walking == false or global.walk_towards_state) and idle < 1) then
 			update_destination_position(steps[step][3][1], steps[step][3][2])
 			global.walk_towards_state = steps[step].walk_towards
@@ -1402,11 +1426,11 @@ local function handle_ontick()
 			idle = idle - 1
 			idled = idled + 1
 
-			debug(string.format("Step: %s, Action: %s, Step: %s - idled for %d", steps[step][1][1]-1, steps[step][1][2], step-1, idled))
+			Debug(string.format("Step: %s, Action: %s, Step: %s - idled for %d", steps[step][1][1]-1, steps[step][1][2], step-1, idled))
 
 			if idle == 0 then
 				idled = 0
-				if steps[step].comment then msg(steps[step].comment) end
+				Comment(steps[step].comment)
 
 				if steps[step][2] == "walk" then
 					update_destination_position(steps[step][3][1], steps[step][3][2])
@@ -1420,7 +1444,7 @@ local function handle_ontick()
 				end
 			end
 		elseif steps[step][2] == "walk" then
-			if steps[step].comment then msg(steps[step].comment) end
+			Comment(steps[step].comment)
 			update_destination_position(steps[step][3][1], steps[step][3][2])
 			global.walk_towards_state = steps[step].walk_towards
 			
@@ -1430,7 +1454,7 @@ local function handle_ontick()
 			change_step(1)
 
 		elseif steps[step][2] == "mine" then
-			if duration and duration == 0 and steps[step].comment then msg(steps[step].comment) end
+			if duration and duration == 0 then Comment(steps[step].comment) end
 			
 			player.update_selected_entity(steps[step][3])
 
@@ -1454,8 +1478,7 @@ local function handle_ontick()
 			mining = mining + 1
 			if mining > 5 then
 				if player.character_mining_progress == 0 then
-					warning(string.format("Step: %s, Action: %s, Step: %s - Mine: Cannot reach resource", steps[step][1][1], steps[step][1][2], step))
-					debug_state = false
+					Error(string.format("Step: %s, Action: %s, Step: %s - Mine: Cannot reach resource", steps[step][1][1], steps[step][1][2], step))
 				else
 					mining = 0
 				end
@@ -1463,13 +1486,13 @@ local function handle_ontick()
 
 		elseif doStep(steps[step]) then
 			-- Do step while standing still
-			if steps[step].comment then msg(steps[step].comment) end
+			Comment(steps[step].comment)
 			step_executed = true
 			change_step(1)
 		end
 	else
 		if global.walk_towards_state and steps[step][2] == "mine" then
-			if duration and duration == 0 and steps[step].comment then msg(steps[step].comment) end
+			if duration and duration == 0 then Comment(steps[step].comment) end
 			
 			player.update_selected_entity(steps[step][3])
 
@@ -1489,8 +1512,7 @@ local function handle_ontick()
 			mining = mining + 1
 			if mining > 5 then
 				if player.character_mining_progress == 0 then
-					warning(string.format("Step: %s, Action: %s, Step: %s - Mine: Cannot reach resource", steps[step][1][1], steps[step][1][2], step))
-					debug_state = false
+					Warning(string.format("Step: %s, Action: %s, Step: %s - Mine: Cannot reach resource", steps[step][1][1], steps[step][1][2], step))
 				else
 					mining = 0
 				end
@@ -1499,7 +1521,7 @@ local function handle_ontick()
 			
 			if doStep(steps[step]) then
 				-- Do step while walking
-				if steps[step].comment then msg(steps[step].comment) end
+				Comment(steps[step].comment)
 				step_executed = true
 				change_step(1)
 			end
@@ -1557,8 +1579,7 @@ local function handle_posttick()
 	if walking.walking or mining~=0 or idle~=0 or pickup_ticks~=0 then
 		-- we wait to finish the previous step before we end the run
 	elseif steps[step] == nil or steps[step][1] == "break" then
-		msg(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
-		debug_state = false
+		Message(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
 		run = false
 		return
 	end
@@ -1583,21 +1604,21 @@ end
 
 local function backwards_compatibility()
 	if steps[step] == nil or steps[step][1] == "break" then
-		debug(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
+		Debug(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
 		debug_state = false
 		return
 	end
 
 	if (steps[step][2] == "pause") then
 		pause()
-		debug("Script paused")
-		debug(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
+		Debug("Script paused")
+		Debug(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
 		debug_state = false
 		return
 	end
 
 	if (steps[step][2] == "speed") then
-		debug(string.format("Step: %s, Action: %s, Step: %s - Game speed: %d", steps[step][1][1], steps[step][1][2], step, steps[step][3]))
+		Debug(string.format("Step: %s, Action: %s, Step: %s - Game speed: %d", steps[step][1][1], steps[step][1][2], step, steps[step][3]))
 		speed(steps[step][3])
 		change_step(1)
 	end
@@ -1618,7 +1639,7 @@ local function backwards_compatibility()
 			idle = idle - 1
 			idled = idled + 1
 
-			debug(string.format("Step: %s, Action: %s, Step: %s - idled for %d", steps[step][1][1]-1, steps[step][1][2], step-1, idled))
+			Debug(string.format("Step: %s, Action: %s, Step: %s - idled for %d", steps[step][1][1]-1, steps[step][1][2], step-1, idled))
 
 			if idle == 0 then
 				idled = 0
@@ -1652,7 +1673,7 @@ local function backwards_compatibility()
 			mining = mining + 1
 			if mining > 5 then
 				if player.character_mining_progress == 0 then
-					warning(string.format("Step: %s, Action: %s, Step: %s - Mine: Cannot reach resource", steps[step][1][1], steps[step][1][2], step))
+					Warning(string.format("Step: %s, Action: %s, Step: %s - Mine: Cannot reach resource", steps[step][1][1], steps[step][1][2], step))
 					debug_state = false
 				else
 					mining = 0
@@ -1709,18 +1730,18 @@ script.on_event(defines.events.on_tick, function(event)
 		if steps[step].comment == "Never Stop" then 
 			never_stop = not never_stop
 
-			msg(string.format("Step: %d - Never Stop: %s", steps[step][1][1], never_stop))
+			Message(string.format("Step: %d - Never Stop: %s", steps[step][1][1], never_stop))
 			not_same_step = step
 		elseif steps[step].comment == "Use All Ticks" then
 			use_all_ticks = not use_all_ticks
 			
-			msg(string.format("Step: %d - Use All Ticks: %s", steps[step][1][1], use_all_ticks))
+			Message(string.format("Step: %d - Use All Ticks: %s", steps[step][1][1], use_all_ticks))
 			not_same_step = step
 		end
 	end
 
 	if steps[step] == nil or steps[step][1] == "break" then
-		debug(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
+		Debug(string.format("(%.2f, %.2f) Complete after %f seconds (%d ticks)", player_position.x, player_position.y, player.online_time / 60, player.online_time))
 		debug_state = false
 		return
 	end

--- a/Lua Files/goals.lua
+++ b/Lua Files/goals.lua
@@ -1,0 +1,77 @@
+require("variables") --gets GOAL
+
+--Config  strings
+local anyp = "Any%"
+local gotlap = "Getting On Track Like A Pro"
+local steelaxe = "Steel Axe"
+
+--Constants 
+local steelaxe_research = "steel-axe"
+local gotlap_filter = {{filter="name", name="locomotive"}}
+
+---Prints game end info and raise victory event
+---@param message string
+local function game_end_simple(message)
+    if global.goal and global.goal.completed then return end
+    global.goal = {completed = true}
+    game.print(
+        {
+            "goal.end_message",
+            message,
+            math.floor(game.tick / (60*60*60)),
+            math.floor((game.tick % (60*60*60)) / (60*60)),
+            math.floor((game.tick % (60*60)) / (60)),
+            math.floor((game.tick % 60) / 60 * 1000),
+            game.tick
+        }
+    )
+end
+
+---Display victory gui
+---@param message string
+local function game_end(message)
+    if global.goal and global.goal.completed then return end
+    game_end_simple(message)
+    game.set_game_state{game_finished = true, player_won = true, "free-play", can_continue = true}
+end
+
+---Event handler for any%
+---@param event EventData.on_rocket_launched
+local function handle_rocket_launch_event(event)
+    if GOAL == anyp then
+        game_end_simple(anyp)
+    end
+end
+
+---Event handler for research event that filters steelaxe
+---@param event EventData.on_research_finished
+local function handle_research_finished_event(event)
+    if GOAL == steelaxe and event.research.name == steelaxe_research then
+        game_end(steelaxe)
+    end
+end
+
+---Event handler for GOTLAP
+---@param event EventData.script_raised_built | EventData.on_built_entity | EventData.on_robot_built_entity
+local function handle_entity_built_event(event)
+    if GOAL == gotlap then
+        game_end(gotlap)
+    end
+end
+
+---Register appropiate event handlers based on configuration
+local function register_event()
+    if GOAL == anyp then
+        script.on_event(defines.events.on_rocket_launched, handle_rocket_launch_event)
+    elseif GOAL == steelaxe then
+        script.on_event(defines.events.on_research_finished, handle_research_finished_event)
+    elseif GOAL ==  gotlap then
+        script.on_event(defines.events.script_raised_built, handle_entity_built_event, gotlap_filter)
+        script.on_event(defines.events.on_built_entity, handle_entity_built_event, gotlap_filter)
+        --script.on_event(defines.events.on_robot_built_entity, gotlap, gotlap_filter) --not needed as robots are not implemented
+    else
+        error("Unknown Goal configuration")
+    end
+end
+
+register_event()

--- a/Lua Files/locale.cfg
+++ b/Lua Files/locale.cfg
@@ -31,3 +31,6 @@ never idle=[font=default-large-bold]Step __1__ [color=yellow]Never idle warning!
 keep walking=[font=default-large-bold]Step __1__ [color=yellow]Keep walking warning![/color][/font] character walk, mine or idle for [font=default-large-bold][color=red]__2__[/color][/font] ticks
 keep on path=[font=default-large-bold]Step __1__ [color=yellow]Keep on path warning![/color][/font] character left path for [font=default-large-bold][color=red]__2__[/color][/font] ticks
 keep crafting=[font=default-large-bold]Step __1__ [color=yellow]Keep crafting warning![/color][/font] character didn't handcraft for [font=default-large-bold][color=red]__2__[/color][/font] ticks
+
+[goal]
+end_message=Congratulation on achiving [font=default-large-bold]__1__![/font]\n[font=default-large-bold]Time:[/font] [font=count-font]__2__h __3__m __4__s __5__ms[/font]\n[font=default-large-bold]Ticks:[/font] [font=count-font]__6__[/font]

--- a/src/Factorio-TAS-Generator.vcxproj
+++ b/src/Factorio-TAS-Generator.vcxproj
@@ -220,18 +220,6 @@
     <CopyFileToFolders Include="..\Lua Files\control.lua">
       <FileType>Document</FileType>
     </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\goal_any_percent.lua">
-      <FileType>Document</FileType>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\goal_debug.lua">
-      <FileType>Document</FileType>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\goal_gotlap.lua">
-      <FileType>Document</FileType>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\goal_steelaxe.lua">
-      <FileType>Document</FileType>
-    </CopyFileToFolders>
     <CopyFileToFolders Include="..\Lua Files\locale.cfg">
       <FileType>Document</FileType>
     </CopyFileToFolders>
@@ -241,6 +229,9 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="misc\wxWidgets.natvis" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\Lua Files\goals.lua" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/Factorio-TAS-Generator.vcxproj.filters
+++ b/src/Factorio-TAS-Generator.vcxproj.filters
@@ -75,22 +75,13 @@
     <CopyFileToFolders Include="..\Lua Files\control.lua">
       <Filter>lua</Filter>
     </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\goal_any_percent.lua">
-      <Filter>lua</Filter>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\goal_debug.lua">
-      <Filter>lua</Filter>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\goal_gotlap.lua">
-      <Filter>lua</Filter>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\goal_steelaxe.lua">
-      <Filter>lua</Filter>
-    </CopyFileToFolders>
     <CopyFileToFolders Include="..\Lua Files\locale.cfg">
       <Filter>lua</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="..\Lua Files\settings.lua">
+      <Filter>lua</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="..\Lua Files\settings-updates.lua">
       <Filter>lua</Filter>
     </CopyFileToFolders>
   </ItemGroup>

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -639,26 +639,105 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_RADIO</property>
-                        <property name="label">Any %</property>
+                        <property name="label">Any%</property>
                         <property name="name">goal_any_percent</property>
                         <property name="permission">none</property>
                         <property name="shortcut"></property>
                         <property name="unchecked_bitmap"></property>
                         <event name="OnMenuSelection">OnMenuAnyPercentClicked</event>
                     </object>
-                    <object class="wxMenuItem" expanded="0">
+                </object>
+                <object class="wxMenu" expanded="1">
+                    <property name="label">Log level</property>
+                    <property name="name">menu_loglevel</property>
+                    <property name="permission">protected</property>
+                    <object class="wxMenuItem" expanded="1">
                         <property name="bitmap"></property>
-                        <property name="checked">0</property>
+                        <property name="checked">1</property>
                         <property name="enabled">1</property>
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_CHECK</property>
+                        <property name="label">Print savegame</property>
+                        <property name="name">logging_savegame</property>
+                        <property name="permission">protected</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnLoggingSavegameSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">1</property>
+                        <property name="enabled">1</property>
+                        <property name="help">Print changes to the research queue to the console</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_CHECK</property>
+                        <property name="label">Print tech</property>
+                        <property name="name">logging_tech</property>
+                        <property name="permission">protected</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnLoggingTechSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">1</property>
+                        <property name="enabled">1</property>
+                        <property name="help">Print step comments to the console</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_CHECK</property>
+                        <property name="label">Print comment</property>
+                        <property name="name">logging_comment</property>
+                        <property name="permission">protected</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnLoggingCommentSelected</event>
+                    </object>
+                    <object class="separator" expanded="1">
+                        <property name="name">loglevel_separaretor</property>
+                        <property name="permission">none</property>
+                    </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help">This is geared towards Debugging. Where all messages are printed to console.</property>
+                        <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_RADIO</property>
                         <property name="label">Debug</property>
-                        <property name="name">goal_debug</property>
+                        <property name="name">loglevel_debug</property>
                         <property name="permission">none</property>
                         <property name="shortcut"></property>
                         <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnMenuDebugClicked</event>
+                        <event name="OnMenuSelection">OnMenuLogDebugSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">1</property>
+                        <property name="enabled">1</property>
+                        <property name="help">This is geared towards TAS Development. Where some messages are printed to the console and some are filtered out.</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_RADIO</property>
+                        <property name="label">Development</property>
+                        <property name="name">loglevel_development</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnMenuLogDevelopmentSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help">This is geared towards TAS Release. Where almost all messages are filtered out, except critical errors.</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_RADIO</property>
+                        <property name="label">Release</property>
+                        <property name="name">loglevel_release</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnMenuLogReleaseSelected</event>
                     </object>
                 </object>
                 <object class="wxMenu" expanded="0">

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -180,14 +180,40 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	menu_goals->Append( goal_GOTLAP );
 
 	wxMenuItem* goal_any_percent;
-	goal_any_percent = new wxMenuItem( menu_goals, wxID_ANY, wxString( wxT("Any %") ) , wxEmptyString, wxITEM_RADIO );
+	goal_any_percent = new wxMenuItem( menu_goals, wxID_ANY, wxString( wxT("Any%") ) , wxEmptyString, wxITEM_RADIO );
 	menu_goals->Append( goal_any_percent );
 
-	wxMenuItem* goal_debug;
-	goal_debug = new wxMenuItem( menu_goals, wxID_ANY, wxString( wxT("Debug") ) , wxEmptyString, wxITEM_RADIO );
-	menu_goals->Append( goal_debug );
-
 	main_menubar->Append( menu_goals, wxT("Goal") );
+
+	menu_loglevel = new wxMenu();
+	logging_savegame = new wxMenuItem( menu_loglevel, wxID_ANY, wxString( wxT("Print savegame") ) , wxEmptyString, wxITEM_CHECK );
+	menu_loglevel->Append( logging_savegame );
+	logging_savegame->Check( true );
+
+	logging_tech = new wxMenuItem( menu_loglevel, wxID_ANY, wxString( wxT("Print tech") ) , wxT("Print changes to the research queue to the console"), wxITEM_CHECK );
+	menu_loglevel->Append( logging_tech );
+	logging_tech->Check( true );
+
+	logging_comment = new wxMenuItem( menu_loglevel, wxID_ANY, wxString( wxT("Print comment") ) , wxT("Print step comments to the console"), wxITEM_CHECK );
+	menu_loglevel->Append( logging_comment );
+	logging_comment->Check( true );
+
+	menu_loglevel->AppendSeparator();
+
+	wxMenuItem* loglevel_debug;
+	loglevel_debug = new wxMenuItem( menu_loglevel, wxID_ANY, wxString( wxT("Debug") ) , wxT("This is geared towards Debugging. Where all messages are printed to console."), wxITEM_RADIO );
+	menu_loglevel->Append( loglevel_debug );
+
+	wxMenuItem* loglevel_development;
+	loglevel_development = new wxMenuItem( menu_loglevel, wxID_ANY, wxString( wxT("Development") ) , wxT("This is geared towards TAS Development. Where some messages are printed to the console and some are filtered out."), wxITEM_RADIO );
+	menu_loglevel->Append( loglevel_development );
+	loglevel_development->Check( true );
+
+	wxMenuItem* loglevel_release;
+	loglevel_release = new wxMenuItem( menu_loglevel, wxID_ANY, wxString( wxT("Release") ) , wxT("This is geared towards TAS Release. Where almost all messages are filtered out, except critical errors."), wxITEM_RADIO );
+	menu_loglevel->Append( loglevel_release );
+
+	main_menubar->Append( menu_loglevel, wxT("Log level") );
 
 	menu_auto_close = new wxMenu();
 	wxMenuItem* auto_close_generate_script;
@@ -1363,7 +1389,12 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuSteelAxeClicked ), this, goal_steelaxe->GetId());
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuGOTLAPClicked ), this, goal_GOTLAP->GetId());
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuAnyPercentClicked ), this, goal_any_percent->GetId());
-	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuDebugClicked ), this, goal_debug->GetId());
+	menu_loglevel->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnLoggingSavegameSelected ), this, logging_savegame->GetId());
+	menu_loglevel->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnLoggingTechSelected ), this, logging_tech->GetId());
+	menu_loglevel->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnLoggingCommentSelected ), this, logging_comment->GetId());
+	menu_loglevel->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuLogDebugSelected ), this, loglevel_debug->GetId());
+	menu_loglevel->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuLogDevelopmentSelected ), this, loglevel_development->GetId());
+	menu_loglevel->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuLogReleaseSelected ), this, loglevel_release->GetId());
 	menu_auto_close->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuAutoCloseGenerateScriptClicked ), this, auto_close_generate_script->GetId());
 	menu_auto_close->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuAutoCloseOpenClicked ), this, auto_close_open->GetId());
 	menu_auto_close->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuAutoCloseSaveClicked ), this, auto_close_save->GetId());

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -59,6 +59,10 @@ class GUI_Base : public wxFrame
 		wxMenu* menu_script;
 		wxMenu* menu_shortcuts;
 		wxMenu* menu_goals;
+		wxMenu* menu_loglevel;
+		wxMenuItem* logging_savegame;
+		wxMenuItem* logging_tech;
+		wxMenuItem* logging_comment;
 		wxMenu* menu_auto_close;
 		wxPanel* detail_panel;
 		wxStaticText* label_x_cord;
@@ -218,7 +222,12 @@ class GUI_Base : public wxFrame
 		virtual void OnMenuSteelAxeClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuGOTLAPClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuAnyPercentClicked( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnMenuDebugClicked( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnLoggingSavegameSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnLoggingTechSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnLoggingCommentSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMenuLogDebugSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMenuLogDevelopmentSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMenuLogReleaseSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuAutoCloseGenerateScriptClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuAutoCloseOpenClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuAutoCloseSaveClicked( wxCommandEvent& event ) { event.Skip(); }

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -26,7 +26,7 @@ class GenerateScript
 {
 public:
 	GenerateScript(wxGrid* grid_steps);
-	void generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, string goal);
+	void generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, string goal, log_config logconfig);
 	const std::string currentDateTime(); // Get current date/time, format is YYYY-MM-DD.HH:mm:ss
 
 private:
@@ -76,6 +76,7 @@ private:
 	string EndSteps();
 	void UnexpectedError(DialogProgressBar* dialog_progress_bar, int error_step);
 
+	void AddVariableFile(string& folder_location, string& goal, log_config logconfig);
 	void AddInfoFile(string& folder_location);
 
 	/// <summary>Paints the step to indicate walk sub-step was added</summary>

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -69,6 +69,9 @@ open_file_return_data* OpenTas::Open(DialogProgressBar* dialog_progress_bar, std
 		}
 	}
 
+	if (!extract_log_config(file))
+		return_data.success = false;
+
 	return &return_data;
 }
 
@@ -627,6 +630,32 @@ bool OpenTas::extract_auto_put(std::ifstream& file)
 
 	return_data.auto_put_recipe = segments[1] == "true";
 
+	return true;
+}
+
+bool OpenTas::extract_log_config(std::ifstream& file)
+{
+	if (!update_segment(file)) // logconfig doesn't exist so default
+	{
+		return_data.logconfig = {
+			.savegame = true,
+			.tech = true,
+			.comment = true,
+			.level = log_config::leveltype::DEV,
+		};
+		return true;
+	}
+	else if (segments[0] != logging_indicator)
+	{
+		return false;
+	}
+	size_t s = segments.size();
+	return_data.logconfig = {
+		.savegame = s < 2 || segments[1] == "1" ? true : false,
+		.tech = s < 3 || segments[2] == "1" ? true : false,
+		.comment = s < 4 || segments[3] == "1" ? true : false,
+		.level = (log_config::leveltype) (s < 5 ? 1 : std::stoi(segments[4])),
+	};
 	return true;
 }
 

--- a/src/OpenTas.h
+++ b/src/OpenTas.h
@@ -42,6 +42,8 @@ struct open_file_return_data
 	bool auto_put_burner = false;
 	bool auto_put_lab = false;
 	bool auto_put_recipe = false;
+
+	log_config logconfig;
 };
 
 enum Category
@@ -77,6 +79,7 @@ private:
 	bool extract_script_location(std::ifstream& file);
 	bool extract_auto_close(std::ifstream& file);
 	bool extract_auto_put(std::ifstream& file);
+	bool extract_log_config(std::ifstream & file);
 
 	bool update_segment(std::ifstream& file);
 };

--- a/src/SaveTas.cpp
+++ b/src/SaveTas.cpp
@@ -13,6 +13,7 @@ bool SaveTas::Save(
 	string folder_location,
 	string folder_location_generate,
 	string goal,
+	log_config logconfig,
 	wxGridBlockCoordsVector selected_rows,
 	bool set_last_location)
 {
@@ -99,7 +100,8 @@ bool SaveTas::Save(
 	string s_selected_rows = "";
 	for (auto p : selected_rows) 
 		s_selected_rows += to_string(p.GetTopRow()) + ";" + to_string(p.GetBottomRow()) + ";";
-	myfile << "selected rows;" << s_selected_rows;
+	myfile << "selected rows;" << s_selected_rows << std::endl;
+	myfile << logging_indicator << ";" << logconfig.to_string();
 
 	myfile.close();
 

--- a/src/SaveTas.h
+++ b/src/SaveTas.h
@@ -11,6 +11,7 @@
 #include "DialogProgressBar.h"
 #include "StepParameters.h"
 #include "TasFileConstants.h"
+#include "utils.h"
 
 using std::string;
 using std::vector;
@@ -29,6 +30,7 @@ public:
 		string folder_location,
 		string folder_location_generate,
 		string goal,
+		log_config logconfig,
 		wxGridBlockCoordsVector selected_rows,
 		bool set_last_location = true
 	);

--- a/src/TasFileConstants.h
+++ b/src/TasFileConstants.h
@@ -24,6 +24,7 @@ static const string save_file_indicator = "Save file location:";
 static const string code_file_indicator = "Step folder location:";
 static const string auto_close_indicator = "Auto close settings:";
 static const string auto_put_indicator = "Auto put settings:";
+static const string logging_indicator = "logging";
 
 static const string auto_close_generate_script_text = "Generate Script";
 static const string auto_close_open_text = "Open";
@@ -37,5 +38,5 @@ static const string auto_put_recipe_text = "Recipe";
 
 static const string goal_steelaxe_text = "Steel Axe";
 static const string goal_GOTLAP_text = "Getting On Track Like A Pro";
-static const string goal_any_percent_text = "Any %";
+static const string goal_any_percent_text = "Any%", goal_any_percent_text_old = "Any %";
 static const string goal_debug_text = "Debug";

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1385,19 +1385,26 @@ void cMain::Open(std::ifstream * file)
 	{
 		menu_goals->GetMenuItems()[1]->Check();
 	}
-	else if (result->goal == goal_any_percent_text)
+	else if (result->goal == goal_any_percent_text || result->goal == goal_any_percent_text_old)
 	{
 		menu_goals->GetMenuItems()[2]->Check();
 	}
 	else if (result->goal == goal_debug_text)
 	{
-		menu_goals->GetMenuItems()[3]->Check();
+		menu_goals->GetMenuItems()[0]->Check();
 	}
 	else
 	{
 		malformed_saved_file_message();
 		return;
 	}
+
+	log_config logconfig = result->logconfig;
+	auto& logmenu = menu_loglevel->GetMenuItems();
+	logmenu[0]->Check(logconfig.savegame);
+	logmenu[1]->Check(logconfig.tech);
+	logmenu[2]->Check(logconfig.comment);
+	logmenu[4 + (int)logconfig.level]->Check();
 
 	menu_auto_close->GetMenuItems()[0]->Check(result->auto_close_generate_script);
 	auto_close_generate_script = result->auto_close_generate_script;
@@ -1587,21 +1594,29 @@ void cMain::OnChooseLocation(wxCommandEvent& event)
 	event.Skip();
 }
 
+std::string cMain::GetGoalConfig()
+{
+	auto& goals_items = menu_goals->GetMenuItems();
+	return goals_items[0]->IsChecked() ? goal_steelaxe_text : goals_items[1]->IsChecked() ? goal_GOTLAP_text : goal_any_percent_text;
+}
+
+log_config cMain::GetLogConfig()
+{
+	auto& logging_items = menu_loglevel->GetMenuItems();
+	log_config logconfig{
+		.savegame = logging_items[0]->IsChecked(),
+		.tech = logging_items[1]->IsChecked(),
+		.comment = logging_items[2]->IsChecked(),
+		.level = logging_items[4]->IsChecked() ? log_config::leveltype::DEBUG : logging_items[5]->IsChecked() ? log_config::leveltype::DEV : log_config::leveltype::RELEASE,
+	};
+	return logconfig;
+}
+
 void cMain::OnGenerateScript(wxCommandEvent& event)
 {
-	std::string goal = "goal_debug.lua";
-	if (menu_goals->GetMenuItems()[0]->IsChecked())
-	{
-		goal = "goal_steelaxe.lua";
-	}
-	else if (menu_goals->GetMenuItems()[1]->IsChecked())
-	{
-		goal = "goal_gotlap.lua";
-	}
-	else if (menu_goals->GetMenuItems()[2]->IsChecked())
-	{
-		goal = "goal_any_percent.lua";
-	}
+	string goal = GetGoalConfig();
+
+	log_config logconfig = GetLogConfig();
 
 	if (!ValidateAllSteps())
 	{
@@ -1609,7 +1624,7 @@ void cMain::OnGenerateScript(wxCommandEvent& event)
 	};
 
 	GenerateScript generate_script(grid_steps);
-	generate_script.generate(this, dialog_progress_bar, StepGridData, generate_code_folder_location, auto_close_generate_script, goal);
+	generate_script.generate(this, dialog_progress_bar, StepGridData, generate_code_folder_location, auto_close_generate_script, goal, logconfig);
 
 	AutoSave();
 
@@ -1960,24 +1975,6 @@ bool cMain::Save(string filename, bool save_as, bool set_last_location)
 		auto_close_save,
 	};
 
-	std::string goal;
-	if (menu_goals->GetMenuItems()[0]->IsChecked())
-	{
-		goal = goal_steelaxe_text;
-	}
-	else if (menu_goals->GetMenuItems()[1]->IsChecked())
-	{
-		goal = goal_GOTLAP_text;
-	}
-	else if (menu_goals->GetMenuItems()[2]->IsChecked())
-	{
-		goal = goal_any_percent_text;
-	}
-	else
-	{
-		goal = goal_debug_text;
-	}
-
 	SaveTas save;
 	return save.Save(
 		this,
@@ -1988,7 +1985,8 @@ bool cMain::Save(string filename, bool save_as, bool set_last_location)
 		template_map,
 		filename,
 		generate_code_folder_location,
-		goal,
+		GetGoalConfig(),
+		GetLogConfig(),
 		grid_steps->GetSelectedRowBlocks(),
 		set_last_location);
 }

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -60,6 +60,8 @@ protected:
 
 	// Script menu items
 	void OnChooseLocation(wxCommandEvent& event);
+	std::string GetGoalConfig();
+	log_config GetLogConfig();
 	void OnGenerateScript(wxCommandEvent& event);
 
 	void OnChangeShortcutMenuSelected(wxCommandEvent & event);

--- a/src/utils.h
+++ b/src/utils.h
@@ -1107,3 +1107,16 @@ static const struct
 	std::string yellow_science = "utility-science-pack";
 	std::string white_science = "space-science-pack";
 } struct_science_list;
+
+struct log_config
+{
+	enum leveltype {DEBUG, DEV, RELEASE};
+	bool savegame,
+		tech,
+		comment;
+	leveltype level;
+	std::string to_string()
+	{
+		return std::to_string(savegame) + ";" + std::to_string(tech) + ";" + std::to_string(comment) + ";" + std::to_string(level) + ";";
+	}
+};


### PR DESCRIPTION
Added dependency on MOD: Speedrun_goals
Added log config to control print level
Added print config for more specific printing control
Added variables.lua file to hold other generated variables 
Removed goal files as goals are now controlled by Speedrun_goals

Goals and log-level now have separate menus. Where the goal is controlled by speedrun goals.

### Speedrun goals
Speedrun goal handles rock yield and always day.

settings-updates.lua controls the settings of speedrun goals, so we can set the settings how we want them.

### Variables
The variables.lua file allows us to insert the variables we want / need without messing with control.lua or steps.lua. As both files are sufficiently large already.

### Log level
I have included 3 levels of logging. So we can reduce the amount of information printed to console more precisely.
We can easily enough introduce new levels with this setup.

In addition more specific settings are introduced to control printing of comment, research queue and save game.