### PR TITLE
Refactor update parameters

### DIFF
--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -81,7 +81,7 @@
                 <property name="window_extra_style"></property>
                 <property name="window_name"></property>
                 <property name="window_style"></property>
-                <object class="wxMenu" expanded="0">
+                <object class="wxMenu" expanded="1">
                     <property name="label">File</property>
                     <property name="name">menu_file</property>
                     <property name="permission">protected</property>
@@ -156,7 +156,7 @@
                         <event name="OnMenuSelection">OnMenuExit</event>
                     </object>
                 </object>
-                <object class="wxMenu" expanded="0">
+                <object class="wxMenu" expanded="1">
                     <property name="label">Script</property>
                     <property name="name">menu_script</property>
                     <property name="permission">protected</property>
@@ -204,8 +204,8 @@
                     </object>
                 </object>
                 <object class="wxMenu" expanded="1">
-                    <property name="label">Shortcuts</property>
-                    <property name="name">menu_shortcuts</property>
+                    <property name="label">Step types</property>
+                    <property name="name">menu_steptypes</property>
                     <property name="permission">protected</property>
                     <object class="wxMenuItem" expanded="0">
                         <property name="bitmap"></property>
@@ -214,12 +214,12 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Change shortcuts</property>
-                        <property name="name">shortcut_changer</property>
+                        <property name="label">Walk</property>
+                        <property name="name">shortcut_walk</property>
                         <property name="permission">none</property>
-                        <property name="shortcut"></property>
+                        <property name="shortcut">Ctrl+2</property>
                         <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnChangeShortcutMenuSelected</event>
+                        <event name="OnMenuSelection">OnWalkMenuSelected</event>
                     </object>
                     <object class="wxMenuItem" expanded="0">
                         <property name="bitmap"></property>
@@ -242,104 +242,6 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Walk</property>
-                        <property name="name">shortcut_walk</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Ctrl+2</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnWalkMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Game Speed</property>
-                        <property name="name">shortcut_game_speed</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Ctrl+3</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnGameSpeedMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Rotate</property>
-                        <property name="name">shortcut_rotate</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Ctrl+4</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnRotateMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Recipe</property>
-                        <property name="name">shortcut_recipe</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Ctrl+5</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnRecipeMenuChosen</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Stop</property>
-                        <property name="name">shortcut_stop</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Ctrl+6</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnStopMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Mine</property>
-                        <property name="name">shortcut_mine</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Alt+1</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnMineMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Build</property>
-                        <property name="name">shortcut_build</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Alt+2</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnBuildMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">Tech</property>
                         <property name="name">shortcut_tech</property>
                         <property name="permission">none</property>
@@ -354,82 +256,12 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Take</property>
-                        <property name="name">shortcut_take</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Alt+4</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnTakeMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Put</property>
-                        <property name="name">shortcut_put</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Alt+5</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnPutMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">Idle</property>
                         <property name="name">shortcut_idle</property>
                         <property name="permission">none</property>
                         <property name="shortcut">Alt+6</property>
                         <property name="unchecked_bitmap"></property>
                         <event name="OnMenuSelection">OnIdleMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Priority</property>
-                        <property name="name">shortcut_priority</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Shift+1</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnPriorityMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Limit</property>
-                        <property name="name">shortcut_limit</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Shift+2</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnLimitMenuSelected</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="0">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
-                        <property name="id">wxID_ANY</property>
-                        <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Filter</property>
-                        <property name="name">shortcut_filter</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut">Shift+3</property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnFilterMenuSelected</event>
                     </object>
                     <object class="wxMenuItem" expanded="0">
                         <property name="bitmap"></property>
@@ -466,6 +298,164 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Cancel Crafting</property>
+                        <property name="name">shortcut_cancel_crafting</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Shift+1</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnCancelCraftingMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Mine</property>
+                        <property name="name">shortcut_mine</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Alt+1</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnMineMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Throw</property>
+                        <property name="name">shortcut_throw</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnThrowMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Shoot</property>
+                        <property name="name">shortcut_shoot</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnShootMenuSelected</event>
+                    </object>
+                    <object class="separator" expanded="0">
+                        <property name="name">steptypes_separator_1</property>
+                        <property name="permission">none</property>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Take</property>
+                        <property name="name">shortcut_take</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Alt+4</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnTakeMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Put</property>
+                        <property name="name">shortcut_put</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Alt+5</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnPutMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Build</property>
+                        <property name="name">shortcut_build</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Alt+2</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnBuildMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Recipe</property>
+                        <property name="name">shortcut_recipe</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Ctrl+5</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnRecipeMenuChosen</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Limit</property>
+                        <property name="name">shortcut_limit</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Shift+2</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnLimitMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Filter</property>
+                        <property name="name">shortcut_filter</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Shift+3</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnFilterMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Priority</property>
+                        <property name="name">shortcut_priority</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Shift+1</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnPriorityMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">Launch</property>
                         <property name="name">shortcut_launch</property>
                         <property name="permission">none</property>
@@ -480,12 +470,30 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Save</property>
-                        <property name="name">shortcut_Save</property>
+                        <property name="label">Rotate</property>
+                        <property name="name">shortcut_rotate</property>
                         <property name="permission">none</property>
-                        <property name="shortcut">Alt+Q</property>
+                        <property name="shortcut">Ctrl+4</property>
                         <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnSaveMenuSelected</event>
+                        <event name="OnMenuSelection">OnRotateMenuSelected</event>
+                    </object>
+                    <object class="separator" expanded="0">
+                        <property name="name">steptypes_separator_2</property>
+                        <property name="permission">none</property>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Game Speed</property>
+                        <property name="name">shortcut_game_speed</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Ctrl+3</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnGameSpeedMenuSelected</event>
                     </object>
                     <object class="wxMenuItem" expanded="0">
                         <property name="bitmap"></property>
@@ -508,12 +516,133 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Stop</property>
+                        <property name="name">shortcut_stop</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Ctrl+6</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnStopMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Save</property>
+                        <property name="name">shortcut_save</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Alt+Q</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnSaveMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Never idle</property>
+                        <property name="name">shortcut_never_idle</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnNeverIdleMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Keep walking</property>
+                        <property name="name">shortcut_keep_walking</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnKeepWalkingMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Keep on path</property>
+                        <property name="name">shortcut_keep_on_path</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnKeepOnPathMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Keep crafting</property>
+                        <property name="name">shortcut_keep_crafting</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnKeepCraftingMenuSelected</event>
+                    </object>
+                </object>
+                <object class="wxMenu" expanded="1">
+                    <property name="label">Shortcuts</property>
+                    <property name="name">menu_shortcuts</property>
+                    <property name="permission">protected</property>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Change shortcuts</property>
+                        <property name="name">shortcut_changer</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnChangeShortcutMenuSelected</event>
+                    </object>
+                    <object class="separator" expanded="1">
+                        <property name="name">shortcuts_separator_1</property>
+                        <property name="permission">none</property>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">Add Step</property>
                         <property name="name">shortcut_add_step</property>
                         <property name="permission">none</property>
                         <property name="shortcut">Alt+A</property>
                         <property name="unchecked_bitmap"></property>
                         <event name="OnMenuSelection">OnAddMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Add Step Under</property>
+                        <property name="name">shortcut_add_step_alt</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Ctrl+A</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnAddAltMenuSelected</event>
                     </object>
                     <object class="wxMenuItem" expanded="0">
                         <property name="bitmap"></property>
@@ -536,12 +665,40 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Change Step Force</property>
+                        <property name="name">shortcut_change_step_alt</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Ctrl+Alt+C</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnChangeAltMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">Delete Step</property>
                         <property name="name">shortcut_delete_step</property>
                         <property name="permission">none</property>
                         <property name="shortcut">Del</property>
                         <property name="unchecked_bitmap"></property>
                         <event name="OnMenuSelection">OnDeleteMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Delete Step Force</property>
+                        <property name="name">shortcut_delete_step_alt</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Ctrl+Del</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnDeleteAltMenuSelected</event>
                     </object>
                     <object class="wxMenuItem" expanded="0">
                         <property name="bitmap"></property>
@@ -564,6 +721,20 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Move Up 5</property>
+                        <property name="name">shortcut_move_up_alt</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnMoveUpAltMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">Move Down</property>
                         <property name="name">shortcut_move_down</property>
                         <property name="permission">none</property>
@@ -578,12 +749,26 @@
                         <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
-                        <property name="label">Cancel Crafting</property>
-                        <property name="name">shortcut_cancel_crafting</property>
+                        <property name="label">Move Down 5</property>
+                        <property name="name">shortcut_move_down_alt</property>
                         <property name="permission">none</property>
-                        <property name="shortcut">Shift+1</property>
+                        <property name="shortcut"></property>
                         <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnCancelCraftingMenuSelected</event>
+                        <event name="OnMenuSelection">OnMoveDownAltMenuSelected</event>
+                    </object>
+                    <object class="wxMenuItem" expanded="0">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help">Finds the nearest searchbox and focuses on it</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Search</property>
+                        <property name="name">shortcut_search</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Ctrl+F</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnSearchMenuSelected</event>
                     </object>
                     <object class="wxMenuItem" expanded="1">
                         <property name="bitmap"></property>
@@ -5582,7 +5767,7 @@
                                         <property name="border">5</property>
                                         <property name="flag">wxALL</property>
                                         <property name="proportion">0</property>
-                                <object class="wxCheckBox" expanded="1">
+                                        <object class="wxCheckBox" expanded="1">
                                             <property name="BottomDockable">1</property>
                                             <property name="LeftDockable">1</property>
                                             <property name="RightDockable">1</property>
@@ -8143,6 +8328,7 @@
                                             <property name="window_name"></property>
                                             <property name="window_style"></property>
                                             <event name="OnButtonClick">OnChangeStepClicked</event>
+                                            <event name="OnRightUp">OnChangeStepRightClicked</event>
                                         </object>
                                     </object>
                                     <object class="sizeritem" expanded="0">
@@ -8218,6 +8404,7 @@
                                             <property name="window_name"></property>
                                             <property name="window_style"></property>
                                             <event name="OnButtonClick">OnDeleteStepClicked</event>
+                                            <event name="OnRightUp">OnDeleteStepRightClicked</event>
                                         </object>
                                     </object>
                                     <object class="sizeritem" expanded="0">
@@ -9411,6 +9598,88 @@
                                                     <property name="hgap">5</property>
                                                     <property name="minimum_size"></property>
                                                     <property name="name">sc_grid_sizer_script</property>
+                                                    <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="rows">0</property>
+                                                    <property name="vgap">5</property>
+                                                </object>
+                                            </object>
+                                        </object>
+                                    </object>
+                                </object>
+                                <object class="listbookpage" expanded="1">
+                                    <property name="bitmap"></property>
+                                    <property name="label">Step types</property>
+                                    <property name="select">0</property>
+                                    <object class="wxPanel" expanded="1">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer"></property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position"></property>
+                                        <property name="aui_row"></property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">sc_panel_steptypes</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style">wxTAB_TRAVERSAL</property>
+                                        <object class="wxBoxSizer" expanded="1">
+                                            <property name="minimum_size"></property>
+                                            <property name="name">sc_steptypes_sizer</property>
+                                            <property name="orient">wxVERTICAL</property>
+                                            <property name="permission">protected</property>
+                                            <object class="sizeritem" expanded="1">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxEXPAND</property>
+                                                <property name="proportion">1</property>
+                                                <object class="wxFlexGridSizer" expanded="1">
+                                                    <property name="cols">3</property>
+                                                    <property name="flexible_direction">wxBOTH</property>
+                                                    <property name="growablecols"></property>
+                                                    <property name="growablerows"></property>
+                                                    <property name="hgap">5</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="name">sc_grid_sizer_steptypes</property>
                                                     <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
                                                     <property name="permission">protected</property>
                                                     <property name="rows">0</property>

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -8012,7 +8012,7 @@
                                             <property name="style">wxTE_PROCESS_ENTER</property>
                                             <property name="subclass">; ; forward_declare</property>
                                             <property name="toolbar_pane">0</property>
-                                            <property name="tooltip"></property>
+                                            <property name="tooltip">Search for a step.&#x0A;&#x0A;( ; ) Semicolon to have multiple search terms [ term1; term2; term3 ].&#x0A;( : ) Colon to specify column [ column:term ].</property>
                                             <property name="validator_data_type"></property>
                                             <property name="validator_style">wxFILTER_NONE</property>
                                             <property name="validator_type">wxDefaultValidator</property>
@@ -8155,7 +8155,7 @@
                                                     <property name="style">wxCLRP_DEFAULT_STYLE|wxCLRP_SHOW_LABEL</property>
                                                     <property name="subclass">; ; forward_declare</property>
                                                     <property name="toolbar_pane">0</property>
-                                                    <property name="tooltip"></property>
+                                                    <property name="tooltip">Select a number of rows to set the colour on them.&#x0A;The colour is automaticly matches the first row of the selected area.</property>
                                                     <property name="validator_data_type"></property>
                                                     <property name="validator_style">wxFILTER_NONE</property>
                                                     <property name="validator_type">wxDefaultValidator</property>
@@ -8243,7 +8243,7 @@
                                             <property name="style"></property>
                                             <property name="subclass">; ; forward_declare</property>
                                             <property name="toolbar_pane">0</property>
-                                            <property name="tooltip"></property>
+                                            <property name="tooltip">Adds a new step to the list above the selected area.&#x0A;Right click: Add the step under the selected area instead.&#x0A;&#x0A;If no rows are selected then it will be placed at the end of the list.&#x0A;</property>
                                             <property name="validator_data_type"></property>
                                             <property name="validator_style">wxFILTER_NONE</property>
                                             <property name="validator_type">wxDefaultValidator</property>
@@ -8319,7 +8319,7 @@
                                             <property name="style"></property>
                                             <property name="subclass">; ; forward_declare</property>
                                             <property name="toolbar_pane">0</property>
-                                            <property name="tooltip"></property>
+                                            <property name="tooltip">Changes the currently selected step to the input.&#x0A;Right click: ignore warnings.</property>
                                             <property name="validator_data_type"></property>
                                             <property name="validator_style">wxFILTER_NONE</property>
                                             <property name="validator_type">wxDefaultValidator</property>
@@ -8395,7 +8395,7 @@
                                             <property name="style"></property>
                                             <property name="subclass">; ; forward_declare</property>
                                             <property name="toolbar_pane">0</property>
-                                            <property name="tooltip"></property>
+                                            <property name="tooltip">Deletes the selected step or steps.&#x0A;Right click: ignore warnings.</property>
                                             <property name="validator_data_type"></property>
                                             <property name="validator_style">wxFILTER_NONE</property>
                                             <property name="validator_type">wxDefaultValidator</property>
@@ -8471,7 +8471,7 @@
                                             <property name="style"></property>
                                             <property name="subclass">; ; forward_declare</property>
                                             <property name="toolbar_pane">0</property>
-                                            <property name="tooltip">Right-click to move 5 but be patient</property>
+                                            <property name="tooltip">Moves the step up.&#x0A;Right click: move 5 but be patient</property>
                                             <property name="validator_data_type"></property>
                                             <property name="validator_style">wxFILTER_NONE</property>
                                             <property name="validator_type">wxDefaultValidator</property>
@@ -8547,7 +8547,7 @@
                                             <property name="style"></property>
                                             <property name="subclass">; ; forward_declare</property>
                                             <property name="toolbar_pane">0</property>
-                                            <property name="tooltip">Right-click to move 5 but be patient</property>
+                                            <property name="tooltip">Moves the step down.&#x0A;Right click: move 5 but be patient</property>
                                             <property name="validator_data_type"></property>
                                             <property name="validator_style">wxFILTER_NONE</property>
                                             <property name="validator_type">wxDefaultValidator</property>

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -1179,6 +1179,8 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	step_search_ctrl->ShowSearchButton( true );
 	#endif
 	step_search_ctrl->ShowCancelButton( true );
+	step_search_ctrl->SetToolTip( wxT("Search for a step.\n\n( ; ) Semicolon to have multiple search terms [ term1; term2; term3 ].\n( : ) Colon to specify column [ column:term ].") );
+
 	step_panel_search_sizer->Add( step_search_ctrl, 0, wxALL, 5 );
 
 	step_search_toggle_updown = new wxCheckBox( step_panel, wxID_ANY, wxT("Search up"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1189,6 +1191,8 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	bSizer65 = new wxBoxSizer( wxHORIZONTAL );
 
 	step_colour_picker = new wxColourPickerCtrl( step_panel, wxID_ANY, wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOW ), wxDefaultPosition, wxDefaultSize, wxCLRP_DEFAULT_STYLE|wxCLRP_SHOW_LABEL );
+	step_colour_picker->SetToolTip( wxT("Select a number of rows to set the colour on them.\nThe colour is automaticly matches the first row of the selected area.") );
+
 	bSizer65->Add( step_colour_picker, 0, wxALL, 5 );
 
 
@@ -1201,21 +1205,27 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	step_panel_control_sizer = new wxBoxSizer( wxHORIZONTAL );
 
 	btn_add_step = new wxButton( step_panel, wxID_ANY, wxT("Add"), wxDefaultPosition, wxDefaultSize, 0 );
+	btn_add_step->SetToolTip( wxT("Adds a new step to the list above the selected area.\nRight click: Add the step under the selected area instead.\n\nIf no rows are selected then it will be placed at the end of the list.\n") );
+
 	step_panel_control_sizer->Add( btn_add_step, 0, wxALIGN_CENTER|wxALL, 5 );
 
 	btn_change_step = new wxButton( step_panel, wxID_ANY, wxT("Change"), wxDefaultPosition, wxDefaultSize, 0 );
+	btn_change_step->SetToolTip( wxT("Changes the currently selected step to the input.\nRight click: ignore warnings.") );
+
 	step_panel_control_sizer->Add( btn_change_step, 0, wxALL, 5 );
 
 	btn_delete_step = new wxButton( step_panel, wxID_ANY, wxT("Delete"), wxDefaultPosition, wxDefaultSize, 0 );
+	btn_delete_step->SetToolTip( wxT("Deletes the selected step or steps.\nRight click: ignore warnings.") );
+
 	step_panel_control_sizer->Add( btn_delete_step, 0, wxALL, 5 );
 
 	btn_move_up = new wxButton( step_panel, wxID_ANY, wxT("Move Up"), wxDefaultPosition, wxDefaultSize, 0 );
-	btn_move_up->SetToolTip( wxT("Right-click to move 5 but be patient") );
+	btn_move_up->SetToolTip( wxT("Moves the step up.\nRight click: move 5 but be patient") );
 
 	step_panel_control_sizer->Add( btn_move_up, 0, wxALL, 5 );
 
 	btn_move_down = new wxButton( step_panel, wxID_ANY, wxT("Move Down"), wxDefaultPosition, wxDefaultSize, 0 );
-	btn_move_down->SetToolTip( wxT("Right-click to move 5 but be patient") );
+	btn_move_down->SetToolTip( wxT("Moves the step down.\nRight click: move 5 but be patient") );
 
 	step_panel_control_sizer->Add( btn_move_down, 0, wxALL, 5 );
 

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -1398,7 +1398,6 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	menu_file->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuExit ), this, menu_file_exit->GetId());
 	menu_script->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnChooseLocation ), this, menu_script_choose_location->GetId());
 	menu_script->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnGenerateScript ), this, menu_script_generate_script->GetId());
-	menu_script->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnOnlyGenerateSteps ), this, menu_script_only_generate_steps->GetId());
 	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnWalkMenuSelected ), this, shortcut_walk->GetId());
 	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnCraftMenuSelected ), this, shortcut_craft->GetId());
 	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnTechMenuSelected ), this, shortcut_tech->GetId());

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -54,114 +54,171 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 
 	main_menubar->Append( menu_script, wxT("Script") );
 
+	menu_steptypes = new wxMenu();
+	wxMenuItem* shortcut_walk;
+	shortcut_walk = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Walk") ) + wxT('\t') + wxT("Ctrl+2"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_walk );
+
+	wxMenuItem* shortcut_craft;
+	shortcut_craft = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Craft") ) + wxT('\t') + wxT("Ctrl+1"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_craft );
+
+	wxMenuItem* shortcut_tech;
+	shortcut_tech = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Tech") ) + wxT('\t') + wxT("Alt+3"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_tech );
+
+	wxMenuItem* shortcut_idle;
+	shortcut_idle = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Idle") ) + wxT('\t') + wxT("Alt+6"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_idle );
+
+	wxMenuItem* shortcut_pick_up;
+	shortcut_pick_up = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Pick Up") ) + wxT('\t') + wxT("Shift+4"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_pick_up );
+
+	wxMenuItem* shortcut_drop;
+	shortcut_drop = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Drop") ) + wxT('\t') + wxT("Shift+5"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_drop );
+
+	wxMenuItem* shortcut_cancel_crafting;
+	shortcut_cancel_crafting = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Cancel Crafting") ) + wxT('\t') + wxT("Shift+1"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_cancel_crafting );
+
+	wxMenuItem* shortcut_mine;
+	shortcut_mine = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Mine") ) + wxT('\t') + wxT("Alt+1"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_mine );
+
+	wxMenuItem* shortcut_throw;
+	shortcut_throw = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Throw") ) , wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_throw );
+
+	wxMenuItem* shortcut_shoot;
+	shortcut_shoot = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Shoot") ) , wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_shoot );
+
+	menu_steptypes->AppendSeparator();
+
+	wxMenuItem* shortcut_take;
+	shortcut_take = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Take") ) + wxT('\t') + wxT("Alt+4"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_take );
+
+	wxMenuItem* shortcut_put;
+	shortcut_put = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Put") ) + wxT('\t') + wxT("Alt+5"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_put );
+
+	wxMenuItem* shortcut_build;
+	shortcut_build = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Build") ) + wxT('\t') + wxT("Alt+2"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_build );
+
+	wxMenuItem* shortcut_recipe;
+	shortcut_recipe = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Recipe") ) + wxT('\t') + wxT("Ctrl+5"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_recipe );
+
+	wxMenuItem* shortcut_limit;
+	shortcut_limit = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Limit") ) + wxT('\t') + wxT("Shift+2"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_limit );
+
+	wxMenuItem* shortcut_filter;
+	shortcut_filter = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Filter") ) + wxT('\t') + wxT("Shift+3"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_filter );
+
+	wxMenuItem* shortcut_priority;
+	shortcut_priority = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Priority") ) + wxT('\t') + wxT("Shift+1"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_priority );
+
+	wxMenuItem* shortcut_launch;
+	shortcut_launch = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Launch") ) + wxT('\t') + wxT("Shift+6"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_launch );
+
+	wxMenuItem* shortcut_rotate;
+	shortcut_rotate = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Rotate") ) + wxT('\t') + wxT("Ctrl+4"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_rotate );
+
+	menu_steptypes->AppendSeparator();
+
+	wxMenuItem* shortcut_game_speed;
+	shortcut_game_speed = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Game Speed") ) + wxT('\t') + wxT("Ctrl+3"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_game_speed );
+
+	wxMenuItem* shortcut_pause;
+	shortcut_pause = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Pause") ) + wxT('\t') + wxT("Alt+R"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_pause );
+
+	wxMenuItem* shortcut_stop;
+	shortcut_stop = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Stop") ) + wxT('\t') + wxT("Ctrl+6"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_stop );
+
+	wxMenuItem* shortcut_save;
+	shortcut_save = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Save") ) + wxT('\t') + wxT("Alt+Q"), wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_save );
+
+	wxMenuItem* shortcut_never_idle;
+	shortcut_never_idle = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Never idle") ) , wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_never_idle );
+
+	wxMenuItem* shortcut_keep_walking;
+	shortcut_keep_walking = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Keep walking") ) , wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_keep_walking );
+
+	wxMenuItem* shortcut_keep_on_path;
+	shortcut_keep_on_path = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Keep on path") ) , wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_keep_on_path );
+
+	wxMenuItem* shortcut_keep_crafting;
+	shortcut_keep_crafting = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Keep crafting") ) , wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( shortcut_keep_crafting );
+
+	main_menubar->Append( menu_steptypes, wxT("Step types") );
+
 	menu_shortcuts = new wxMenu();
 	wxMenuItem* shortcut_changer;
 	shortcut_changer = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Change shortcuts") ) , wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_changer );
 
-	wxMenuItem* shortcut_craft;
-	shortcut_craft = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Craft") ) + wxT('\t') + wxT("Ctrl+1"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_craft );
-
-	wxMenuItem* shortcut_walk;
-	shortcut_walk = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Walk") ) + wxT('\t') + wxT("Ctrl+2"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_walk );
-
-	wxMenuItem* shortcut_game_speed;
-	shortcut_game_speed = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Game Speed") ) + wxT('\t') + wxT("Ctrl+3"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_game_speed );
-
-	wxMenuItem* shortcut_rotate;
-	shortcut_rotate = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Rotate") ) + wxT('\t') + wxT("Ctrl+4"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_rotate );
-
-	wxMenuItem* shortcut_recipe;
-	shortcut_recipe = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Recipe") ) + wxT('\t') + wxT("Ctrl+5"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_recipe );
-
-	wxMenuItem* shortcut_stop;
-	shortcut_stop = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Stop") ) + wxT('\t') + wxT("Ctrl+6"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_stop );
-
-	wxMenuItem* shortcut_mine;
-	shortcut_mine = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Mine") ) + wxT('\t') + wxT("Alt+1"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_mine );
-
-	wxMenuItem* shortcut_build;
-	shortcut_build = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Build") ) + wxT('\t') + wxT("Alt+2"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_build );
-
-	wxMenuItem* shortcut_tech;
-	shortcut_tech = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Tech") ) + wxT('\t') + wxT("Alt+3"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_tech );
-
-	wxMenuItem* shortcut_take;
-	shortcut_take = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Take") ) + wxT('\t') + wxT("Alt+4"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_take );
-
-	wxMenuItem* shortcut_put;
-	shortcut_put = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Put") ) + wxT('\t') + wxT("Alt+5"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_put );
-
-	wxMenuItem* shortcut_idle;
-	shortcut_idle = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Idle") ) + wxT('\t') + wxT("Alt+6"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_idle );
-
-	wxMenuItem* shortcut_priority;
-	shortcut_priority = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Priority") ) + wxT('\t') + wxT("Shift+1"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_priority );
-
-	wxMenuItem* shortcut_limit;
-	shortcut_limit = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Limit") ) + wxT('\t') + wxT("Shift+2"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_limit );
-
-	wxMenuItem* shortcut_filter;
-	shortcut_filter = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Filter") ) + wxT('\t') + wxT("Shift+3"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_filter );
-
-	wxMenuItem* shortcut_pick_up;
-	shortcut_pick_up = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Pick Up") ) + wxT('\t') + wxT("Shift+4"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_pick_up );
-
-	wxMenuItem* shortcut_drop;
-	shortcut_drop = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Drop") ) + wxT('\t') + wxT("Shift+5"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_drop );
-
-	wxMenuItem* shortcut_launch;
-	shortcut_launch = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Launch") ) + wxT('\t') + wxT("Shift+6"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_launch );
-
-	wxMenuItem* shortcut_Save;
-	shortcut_Save = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Save") ) + wxT('\t') + wxT("Alt+Q"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_Save );
-
-	wxMenuItem* shortcut_pause;
-	shortcut_pause = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Pause") ) + wxT('\t') + wxT("Alt+R"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_pause );
+	menu_shortcuts->AppendSeparator();
 
 	wxMenuItem* shortcut_add_step;
 	shortcut_add_step = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Add Step") ) + wxT('\t') + wxT("Alt+A"), wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_add_step );
 
+	wxMenuItem* shortcut_add_step_alt;
+	shortcut_add_step_alt = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Add Step Under") ) + wxT('\t') + wxT("Ctrl+A"), wxEmptyString, wxITEM_NORMAL );
+	menu_shortcuts->Append( shortcut_add_step_alt );
+
 	wxMenuItem* shortcut_change_step;
 	shortcut_change_step = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Change Step") ) + wxT('\t') + wxT("Alt+C"), wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_change_step );
+
+	wxMenuItem* shortcut_change_step_alt;
+	shortcut_change_step_alt = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Change Step Force") ) + wxT('\t') + wxT("Ctrl+Alt+C"), wxEmptyString, wxITEM_NORMAL );
+	menu_shortcuts->Append( shortcut_change_step_alt );
 
 	wxMenuItem* shortcut_delete_step;
 	shortcut_delete_step = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Delete Step") ) + wxT('\t') + wxT("Del"), wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_delete_step );
 
+	wxMenuItem* shortcut_delete_step_alt;
+	shortcut_delete_step_alt = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Delete Step Force") ) + wxT('\t') + wxT("Ctrl+Del"), wxEmptyString, wxITEM_NORMAL );
+	menu_shortcuts->Append( shortcut_delete_step_alt );
+
 	wxMenuItem* shortcut_move_up;
 	shortcut_move_up = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Move Up") ) + wxT('\t') + wxT("Alt+W"), wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_move_up );
+
+	wxMenuItem* shortcut_move_up_alt;
+	shortcut_move_up_alt = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Move Up 5") ) , wxEmptyString, wxITEM_NORMAL );
+	menu_shortcuts->Append( shortcut_move_up_alt );
 
 	wxMenuItem* shortcut_move_down;
 	shortcut_move_down = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Move Down") ) + wxT('\t') + wxT("Alt+S"), wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_move_down );
 
-	wxMenuItem* shortcut_cancel_crafting;
-	shortcut_cancel_crafting = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Cancel Crafting") ) + wxT('\t') + wxT("Shift+1"), wxEmptyString, wxITEM_NORMAL );
-	menu_shortcuts->Append( shortcut_cancel_crafting );
+	wxMenuItem* shortcut_move_down_alt;
+	shortcut_move_down_alt = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Move Down 5") ) , wxEmptyString, wxITEM_NORMAL );
+	menu_shortcuts->Append( shortcut_move_down_alt );
+
+	wxMenuItem* shortcut_search;
+	shortcut_search = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Search") ) + wxT('\t') + wxT("Ctrl+F"), wxT("Finds the nearest searchbox and focuses on it"), wxITEM_NORMAL );
+	menu_shortcuts->Append( shortcut_search );
 
 	wxMenuItem* shortcut_undo;
 	shortcut_undo = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Undo") ) + wxT('\t') + wxT("Ctrl+Z"), wxEmptyString, wxITEM_NORMAL );
@@ -1336,33 +1393,45 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	menu_script->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnChooseLocation ), this, menu_script_choose_location->GetId());
 	menu_script->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnGenerateScript ), this, menu_script_generate_script->GetId());
 	menu_script->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnOnlyGenerateSteps ), this, menu_script_only_generate_steps->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnWalkMenuSelected ), this, shortcut_walk->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnCraftMenuSelected ), this, shortcut_craft->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnTechMenuSelected ), this, shortcut_tech->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnIdleMenuSelected ), this, shortcut_idle->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnPickUpMenuSelected ), this, shortcut_pick_up->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnDropMenuSelected ), this, shortcut_drop->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnCancelCraftingMenuSelected ), this, shortcut_cancel_crafting->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMineMenuSelected ), this, shortcut_mine->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnThrowMenuSelected ), this, shortcut_throw->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnShootMenuSelected ), this, shortcut_shoot->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnTakeMenuSelected ), this, shortcut_take->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnPutMenuSelected ), this, shortcut_put->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnBuildMenuSelected ), this, shortcut_build->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnRecipeMenuChosen ), this, shortcut_recipe->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnLimitMenuSelected ), this, shortcut_limit->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnFilterMenuSelected ), this, shortcut_filter->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnPriorityMenuSelected ), this, shortcut_priority->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnLaunchMenuSelected ), this, shortcut_launch->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnRotateMenuSelected ), this, shortcut_rotate->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnGameSpeedMenuSelected ), this, shortcut_game_speed->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnPauseMenuSelected ), this, shortcut_pause->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnStopMenuSelected ), this, shortcut_stop->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnSaveMenuSelected ), this, shortcut_save->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnNeverIdleMenuSelected ), this, shortcut_never_idle->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnKeepWalkingMenuSelected ), this, shortcut_keep_walking->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnKeepOnPathMenuSelected ), this, shortcut_keep_on_path->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnKeepCraftingMenuSelected ), this, shortcut_keep_crafting->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnChangeShortcutMenuSelected ), this, shortcut_changer->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnCraftMenuSelected ), this, shortcut_craft->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnWalkMenuSelected ), this, shortcut_walk->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnGameSpeedMenuSelected ), this, shortcut_game_speed->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnRotateMenuSelected ), this, shortcut_rotate->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnRecipeMenuChosen ), this, shortcut_recipe->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnStopMenuSelected ), this, shortcut_stop->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMineMenuSelected ), this, shortcut_mine->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnBuildMenuSelected ), this, shortcut_build->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnTechMenuSelected ), this, shortcut_tech->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnTakeMenuSelected ), this, shortcut_take->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnPutMenuSelected ), this, shortcut_put->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnIdleMenuSelected ), this, shortcut_idle->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnPriorityMenuSelected ), this, shortcut_priority->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnLimitMenuSelected ), this, shortcut_limit->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnFilterMenuSelected ), this, shortcut_filter->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnPickUpMenuSelected ), this, shortcut_pick_up->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnDropMenuSelected ), this, shortcut_drop->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnLaunchMenuSelected ), this, shortcut_launch->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnSaveMenuSelected ), this, shortcut_Save->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnPauseMenuSelected ), this, shortcut_pause->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnAddMenuSelected ), this, shortcut_add_step->GetId());
+	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnAddAltMenuSelected ), this, shortcut_add_step_alt->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnChangeMenuSelected ), this, shortcut_change_step->GetId());
+	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnChangeAltMenuSelected ), this, shortcut_change_step_alt->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnDeleteMenuSelected ), this, shortcut_delete_step->GetId());
+	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnDeleteAltMenuSelected ), this, shortcut_delete_step_alt->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMoveUpMenuSelected ), this, shortcut_move_up->GetId());
+	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMoveUpAltMenuSelected ), this, shortcut_move_up_alt->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMoveDownMenuSelected ), this, shortcut_move_down->GetId());
-	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnCancelCraftingMenuSelected ), this, shortcut_cancel_crafting->GetId());
+	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMoveDownAltMenuSelected ), this, shortcut_move_down_alt->GetId());
+	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnSearchMenuSelected ), this, shortcut_search->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnUndoMenuSelected ), this, shortcut_undo->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnRedoMenuSelected ), this, shortcut_redo->GetId());
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuSteelAxeClicked ), this, goal_steelaxe->GetId());
@@ -1423,7 +1492,9 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	btn_add_step->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnAddStepClicked ), NULL, this );
 	btn_add_step->Connect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GUI_Base::OnAddStepRightClicked ), NULL, this );
 	btn_change_step->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnChangeStepClicked ), NULL, this );
+	btn_change_step->Connect( wxEVT_RIGHT_UP, wxMouseEventHandler( GUI_Base::OnChangeStepRightClicked ), NULL, this );
 	btn_delete_step->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnDeleteStepClicked ), NULL, this );
+	btn_delete_step->Connect( wxEVT_RIGHT_UP, wxMouseEventHandler( GUI_Base::OnDeleteStepRightClicked ), NULL, this );
 	btn_move_up->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnMoveUpClicked ), NULL, this );
 	btn_move_up->Connect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GUI_Base::OnMoveUpFiveClicked ), NULL, this );
 	btn_move_down->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnMoveDownClicked ), NULL, this );
@@ -1498,7 +1569,9 @@ GUI_Base::~GUI_Base()
 	btn_add_step->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnAddStepClicked ), NULL, this );
 	btn_add_step->Disconnect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GUI_Base::OnAddStepRightClicked ), NULL, this );
 	btn_change_step->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnChangeStepClicked ), NULL, this );
+	btn_change_step->Disconnect( wxEVT_RIGHT_UP, wxMouseEventHandler( GUI_Base::OnChangeStepRightClicked ), NULL, this );
 	btn_delete_step->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnDeleteStepClicked ), NULL, this );
+	btn_delete_step->Disconnect( wxEVT_RIGHT_UP, wxMouseEventHandler( GUI_Base::OnDeleteStepRightClicked ), NULL, this );
 	btn_move_up->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnMoveUpClicked ), NULL, this );
 	btn_move_up->Disconnect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GUI_Base::OnMoveUpFiveClicked ), NULL, this );
 	btn_move_down->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnMoveDownClicked ), NULL, this );
@@ -1569,6 +1642,21 @@ Shortcut_changer::Shortcut_changer( wxWindow* parent, wxWindowID id, const wxStr
 	sc_panel_script->Layout();
 	sc_script_sizer->Fit( sc_panel_script );
 	sc_item_book->AddPage( sc_panel_script, wxT("Script"), false );
+	sc_panel_steptypes = new wxPanel( sc_item_book, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	sc_steptypes_sizer = new wxBoxSizer( wxVERTICAL );
+
+	sc_grid_sizer_steptypes = new wxFlexGridSizer( 0, 3, 5, 5 );
+	sc_grid_sizer_steptypes->SetFlexibleDirection( wxBOTH );
+	sc_grid_sizer_steptypes->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+
+
+	sc_steptypes_sizer->Add( sc_grid_sizer_steptypes, 1, wxEXPAND, 5 );
+
+
+	sc_panel_steptypes->SetSizer( sc_steptypes_sizer );
+	sc_panel_steptypes->Layout();
+	sc_steptypes_sizer->Fit( sc_panel_steptypes );
+	sc_item_book->AddPage( sc_panel_steptypes, wxT("Step types"), false );
 	sc_panel_shortcuts = new wxPanel( sc_item_book, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
 	sc_shortcuts_sizer = new wxBoxSizer( wxVERTICAL );
 

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -187,8 +187,6 @@ class GUI_Base : public wxFrame
 		virtual void OnMenuExit( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnChooseLocation( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnGenerateScript( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnChangeShortcutMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnCraftMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnWalkMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCraftMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnTechMenuSelected( wxCommandEvent& event ) { event.Skip(); }

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -57,6 +57,7 @@ class GUI_Base : public wxFrame
 		wxMenuBar* main_menubar;
 		wxMenu* menu_file;
 		wxMenu* menu_script;
+		wxMenu* menu_steptypes;
 		wxMenu* menu_shortcuts;
 		wxMenu* menu_goals;
 		wxMenu* menu_auto_close;
@@ -187,33 +188,45 @@ class GUI_Base : public wxFrame
 		virtual void OnChooseLocation( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnGenerateScript( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnOnlyGenerateSteps( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnChangeShortcutMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnCraftMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnWalkMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnGameSpeedMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnRotateMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnRecipeMenuChosen( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnStopMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnMineMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnBuildMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnCraftMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnTechMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnTakeMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnPutMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnIdleMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnPriorityMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnLimitMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnFilterMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnPickUpMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnDropMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnLaunchMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnSaveMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnPauseMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnAddMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnChangeMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnDeleteMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnMoveUpMenuSelected( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnMoveDownMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCancelCraftingMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMineMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnThrowMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnShootMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnTakeMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnPutMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnBuildMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnRecipeMenuChosen( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnLimitMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnFilterMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnPriorityMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnLaunchMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnRotateMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnGameSpeedMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnPauseMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnStopMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnSaveMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnNeverIdleMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnKeepWalkingMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnKeepOnPathMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnKeepCraftingMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnChangeShortcutMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnAddMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnAddAltMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnChangeMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnChangeAltMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnDeleteMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnDeleteAltMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMoveUpMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMoveUpAltMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMoveDownMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMoveDownAltMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnSearchMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnUndoMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnRedoMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuSteelAxeClicked( wxCommandEvent& event ) { event.Skip(); }
@@ -274,7 +287,9 @@ class GUI_Base : public wxFrame
 		virtual void OnAddStepClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnAddStepRightClicked( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnChangeStepClicked( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnChangeStepRightClicked( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnDeleteStepClicked( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnDeleteStepRightClicked( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnMoveUpClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMoveUpFiveClicked( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnMoveDownClicked( wxCommandEvent& event ) { event.Skip(); }
@@ -320,6 +335,9 @@ class Shortcut_changer : public wxDialog
 		wxPanel* sc_panel_script;
 		wxBoxSizer* sc_script_sizer;
 		wxFlexGridSizer* sc_grid_sizer_script;
+		wxPanel* sc_panel_steptypes;
+		wxBoxSizer* sc_steptypes_sizer;
+		wxFlexGridSizer* sc_grid_sizer_steptypes;
 		wxPanel* sc_panel_shortcuts;
 		wxBoxSizer* sc_shortcuts_sizer;
 		wxFlexGridSizer* sc_grid_sizer_shortcuts;

--- a/src/ParameterChoices.h
+++ b/src/ParameterChoices.h
@@ -61,7 +61,7 @@ const struct parameter_choices_struct
 	put = building | container,
 	rotate = building | amount,
 	limit = building | amount,
-	priority = building | priority_io,
+	priority = building - building_orientation | priority_io,
 	recipe = building | amount | item,
 	filter = building | amount | item,
 	launch = point | comment;
@@ -69,3 +69,35 @@ const struct parameter_choices_struct
 	//misc
 	const int drop = point | item | comment;
 } parameter_choices;
+
+// vector StepType to parameter_choices
+const vector<int> listStepTypeToParameterChoices = {
+	0, // for indexing
+	parameter_choices.stop, 
+	parameter_choices.build, 
+	parameter_choices.craft, 
+	parameter_choices.game_speed, 
+	parameter_choices.Pause, 
+	parameter_choices.save, 
+	parameter_choices.recipe, 
+	parameter_choices.limit, 
+	parameter_choices.filter, 
+	parameter_choices.rotate, 
+	parameter_choices.priority, 
+	parameter_choices.put, 
+	parameter_choices.take, 
+	parameter_choices.mining,
+	parameter_choices.launch, 
+	parameter_choices.walk, 
+	parameter_choices.tech, 
+	parameter_choices.drop, 
+	parameter_choices.pick, 
+	parameter_choices.idle, 
+	parameter_choices.cancel_crafting,
+	parameter_choices.never_idle, 
+	parameter_choices.keep_walking, 
+	parameter_choices.keep_on_path, 
+	parameter_choices.keep_crafting, 
+	parameter_choices.shoot, 
+	parameter_choices._throw
+};

--- a/src/SearchUtil.cpp
+++ b/src/SearchUtil.cpp
@@ -19,7 +19,7 @@ tuple<vector<int>, wxString> Search::HandleColon(const wxString& s)
 	vector<int> c; //casd
 	if (column == "any")
 	{
-		c.reserve(5);
+		c.reserve(6);
 		double text_todouble_throwaway = 0;
 		
 		if (text.ToDouble(&text_todouble_throwaway))
@@ -27,8 +27,8 @@ tuple<vector<int>, wxString> Search::HandleColon(const wxString& s)
 			c.push_back(1);
 			c.push_back(2);
 			c.push_back(3);
-			c.push_back(7);
 			c.push_back(8);
+			c.push_back(9);
 		}
 		else
 		{
@@ -36,7 +36,8 @@ tuple<vector<int>, wxString> Search::HandleColon(const wxString& s)
 			c.push_back(4);
 			c.push_back(5);
 			c.push_back(6);
-			c.push_back(9);
+			c.push_back(7);
+			c.push_back(10);
 		}
 	}
 	else

--- a/src/ShortcutChanger.cpp
+++ b/src/ShortcutChanger.cpp
@@ -25,6 +25,7 @@ void ShortcutChanger::Build(wxMenuBar* menu)
 	vector<std::tuple<wxGridSizer*, string, wxPanel*, wxSizer*> > grids = {
 		{sc_grid_sizer_file, "File", sc_panel_file, sc_file_sizer},
 		{sc_grid_sizer_script, "Script", sc_panel_script, sc_script_sizer},
+		{sc_grid_sizer_steptypes, "Step types", sc_panel_steptypes, sc_steptypes_sizer},
 		{sc_grid_sizer_shortcuts, "Shortcuts", sc_panel_shortcuts, sc_shortcuts_sizer},
 		{sc_grid_sizer_goals, "Goal", sc_panel_goals, sc_goal_sizer},
 		{sc_grid_sizer_auto, "Auto-close", sc_panel_auto, sc_auto_sizer},

--- a/src/ShortcutChanger.cpp
+++ b/src/ShortcutChanger.cpp
@@ -14,13 +14,9 @@ void ShortcutChanger::Build(wxMenuBar* menu)
 		for (auto& [key, value] : map)
 		{
 			if (s.shortcuts[menu].contains(key))
-				continue;
-			else
-				s.shortcuts[menu][key] = value;
+				state.shortcuts[menu][key] = s.shortcuts[menu][key];
 		}
 	}
-
-	state = s;
 
 	vector<std::tuple<wxGridSizer*, string, wxPanel*, wxSizer*> > grids = {
 		{sc_grid_sizer_file, "File", sc_panel_file, sc_file_sizer},

--- a/src/TypePanel.cpp
+++ b/src/TypePanel.cpp
@@ -546,6 +546,20 @@ void cMain::OnMineMenuSelected(wxCommandEvent& event)
 	event.Skip();
 }
 
+void cMain::OnThrowMenuSelected(wxCommandEvent& event)
+{
+	type_panel->SwitchStep(e_throw);
+	OnThrowChosen(event);
+	event.Skip();
+}
+
+void cMain::OnShootMenuSelected(wxCommandEvent& event)
+{
+	type_panel->SwitchStep(e_shoot);
+	OnShootChosen(event);
+	event.Skip();
+}
+
 void cMain::OnGameSpeedMenuSelected(wxCommandEvent& event)
 {
 	type_panel->SwitchStep(e_game_speed);
@@ -669,6 +683,34 @@ void cMain::OnSaveMenuSelected(wxCommandEvent& event)
 {
 	type_panel->SwitchStep(e_save);
 	OnSaveChosen(event);
+	event.Skip();
+}
+
+void cMain::OnNeverIdleMenuSelected(wxCommandEvent& event)
+{
+	type_panel->SwitchStep(e_never_idle);
+	OnNeverIdleChosen(event);
+	event.Skip();
+}
+
+void cMain::OnKeepWalkingMenuSelected(wxCommandEvent& event)
+{
+	type_panel->SwitchStep(e_keep_walking);
+	OnKeepWalkingChosen(event);
+	event.Skip();
+}
+
+void cMain::OnKeepOnPathMenuSelected(wxCommandEvent& event)
+{
+	type_panel->SwitchStep(e_keep_on_path);
+	OnKeepOnPathChosen(event);
+	event.Skip();
+}
+
+void cMain::OnKeepCraftingMenuSelected(wxCommandEvent& event)
+{
+	type_panel->SwitchStep(e_keep_crafting);
+	OnKeepCraftingChosen(event);
 	event.Skip();
 }
 

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1789,235 +1789,107 @@ void cMain::UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event, bool c
 	modifier_split_checkbox->SetValue(modifiers.find("split") != std::string::npos);
 
 	StepType step = ToStepType(gridEntry->Step.ToStdString());
+	int parameters = listStepTypeToParameterChoices[step];
 
-	string OrientationEnum = "";
+	string OrientationEnum = gridEntry->BuildingOrientation.ToStdString();
 	float speed;
-	long long pos;
+	size_t pos = OrientationEnum.find(",");
+
+	using enum choice_bit_vector;
+	if (parameters & x_coordinate) spin_x->SetValue(gridEntry->X);
+	if (parameters & y_coordinate) spin_y->SetValue(gridEntry->Y);
+	if (parameters & amount) spin_amount->SetValue(gridEntry->Amount);
+	if (parameters & item) cmb_item->SetValue(gridEntry->Item);
+	if (parameters & from_to) cmb_from_into->SetValue(gridEntry->BuildingOrientation);
+	if (parameters & input) radio_input->Select(map_input_output[OrientationEnum.substr(0, pos)]);
+	if (parameters & output) radio_output->Select(map_input_output[OrientationEnum.substr(pos + 1)]);
+	if (parameters & building_orientation) cmb_building_orientation->SetValue(gridEntry->BuildingOrientation);
+	if (parameters & direction_to_build) cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
+	if (parameters & building_size) spin_building_size->SetValue(gridEntry->BuildingSize);
+	if (parameters & amount_of_buildings) spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
+	if (parameters & comment) txt_comment->SetValue(gridEntry->Comment);
+
 	switch (step)
 	{
-		case e_stop:
-			if (changeType) OnStopMenuSelected(event);
-			txt_comment->SetValue(gridEntry->Comment);
-
-			return;
 		case e_build:
 			if (changeType) OnBuildMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			cmb_item->SetValue(gridEntry->Item);
-			cmb_building_orientation->SetValue(gridEntry->BuildingOrientation);
-			cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
-			spin_building_size->SetValue(gridEntry->BuildingSize);
-			spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_craft:
 			if (changeType) OnCraftMenuSelected(event);
-			spin_amount->SetValue(gridEntry->Amount);
-			cmb_item->SetValue(gridEntry->Item);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_game_speed:
 			if (changeType) OnGameSpeedMenuSelected(event);
 			speed = stof(gridEntry->Amount.ToStdString()) * 100.0;
 			spin_amount->SetValue(speed);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_pause:
 			if (changeType) OnPauseMenuSelected(event);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_save:
 			if (changeType) OnSaveMenuSelected(event);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_never_idle:
-			if (changeType) OnNeverIdleChosen(event);
-			txt_comment->SetValue(gridEntry->Comment);
-
+			if (changeType) OnNeverIdleMenuSelected(event);
 			return;
 		case e_keep_walking:
-			if (changeType) OnKeepWalkingChosen(event);
-			txt_comment->SetValue(gridEntry->Comment);
-
+			if (changeType) OnKeepWalkingMenuSelected(event);
 			return;
 		case e_keep_crafting:
-			if (changeType) OnKeepCraftingChosen(event);
-			txt_comment->SetValue(gridEntry->Comment);
-
+			if (changeType) OnKeepCraftingMenuSelected(event);
 			return;
 		case e_keep_on_path:
-			if (changeType) OnKeepOnPathChosen(event);
-			txt_comment->SetValue(gridEntry->Comment);
-
+			if (changeType) OnKeepOnPathMenuSelected(event);
 			return;
 		case e_recipe:
 			if (changeType) OnRecipeMenuChosen(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			spin_amount->SetValue(gridEntry->Amount);
-			cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
-			spin_building_size->SetValue(gridEntry->BuildingSize);
-			spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
-			cmb_item->SetValue(gridEntry->Item);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_limit:
 			if (changeType) OnLimitMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			spin_amount->SetValue(gridEntry->Amount);
-			cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
-			spin_building_size->SetValue(gridEntry->BuildingSize);
-			spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_filter:
 			if (changeType) OnFilterMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			spin_amount->SetValue(gridEntry->Amount);
-			cmb_item->SetValue(gridEntry->Item);
-			cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
-			spin_building_size->SetValue(gridEntry->BuildingSize);
-			spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_rotate:
 			if (changeType) OnRotateMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			spin_amount->SetValue(gridEntry->Amount);
-			txt_comment->SetValue(gridEntry->Comment);
-
-			cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
-			spin_building_size->SetValue(gridEntry->BuildingSize);
-			spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
-
 			return;
 		case e_priority:
 			if (changeType) OnPriorityMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
-			spin_building_size->SetValue(gridEntry->BuildingSize);
-			spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
-
-			OrientationEnum = gridEntry->BuildingOrientation.ToStdString();
-			pos = OrientationEnum.find(",");
-
-			radio_input->Select(map_input_output[OrientationEnum.substr(0, pos)]);
-			radio_output->Select(map_input_output[OrientationEnum.substr(pos + 1)]);
-
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_put:
 			if (changeType) OnPutMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			spin_amount->SetValue(gridEntry->Amount);
-			cmb_item->SetValue(gridEntry->Item);
-			cmb_from_into->SetValue(gridEntry->BuildingOrientation);
-			cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
-			spin_building_size->SetValue(gridEntry->BuildingSize);
-			spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_take:
 			if (changeType) OnTakeMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			spin_amount->SetValue(gridEntry->Amount);
-			cmb_item->SetValue(gridEntry->Item);
-			cmb_from_into->SetValue(gridEntry->BuildingOrientation);
-			cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
-			spin_building_size->SetValue(gridEntry->BuildingSize);
-			spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_mine:
 			if (changeType) OnMineMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			spin_amount->SetValue(gridEntry->Amount);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_launch:
 			if (changeType) OnLaunchMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_walk:
-			OnWalkMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			txt_comment->SetValue(gridEntry->Comment);
-
+			if (changeType) OnWalkMenuSelected(event);
 			return;
 		case e_tech:
 			if (changeType) OnTechMenuSelected(event);
-			cmb_item->SetValue(gridEntry->Item);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_drop:
 			if (changeType) OnDropMenuSelected(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			cmb_item->SetValue(gridEntry->Item);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_pick_up:
 			if (changeType) OnPickUpMenuSelected(event);
-			spin_amount->SetValue(gridEntry->Amount);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		case e_idle:
 			if (changeType) OnIdleMenuSelected(event);
-			spin_amount->SetValue(gridEntry->Amount);
-			txt_comment->SetValue(gridEntry->Comment);
-		
 			return;
-
 		case e_shoot:
-			if (changeType) OnShootChosen(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			spin_amount->SetValue(gridEntry->Amount);
-			txt_comment->SetValue(gridEntry->Comment);
-
+			if (changeType) OnShootMenuSelected(event);
 			return;
-
 		case e_throw:
-			if (changeType) OnThrowChosen(event);
-			spin_x->SetValue(gridEntry->X);
-			spin_y->SetValue(gridEntry->Y);
-			cmb_item->SetValue(gridEntry->Item);
-			txt_comment->SetValue(gridEntry->Comment);
-
+			if (changeType) OnThrowMenuSelected(event);
 			return;
 		case e_cancel_crafting:
 			if (changeType) OnCancelCraftingMenuSelected(event);
-			cmb_item->SetValue(gridEntry->Item);
-			spin_amount->SetValue(gridEntry->Amount);
-			txt_comment->SetValue(gridEntry->Comment);
-
 			return;
 		default:
 			return;

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -716,21 +716,7 @@ void cMain::OnChangeStepClicked(wxCommandEvent& event)
 		}
 	}
 
-	auto stepParameters = ExtractStepParameters();
-
-	if (!ValidateStep(row, stepParameters))
-	{
-		return;
-	};
-
-	stack.Push({
-		.row = row,
-		.type = T_MODIFY,
-		.rows = ChangeStep(row, stepParameters)
-	});
-
-	grid_steps->SelectRow(row);
-	no_changes = false;
+	OnChangeStepInternal(rows, row);
 }
 
 void cMain::OnChangeStepRightClicked(wxMouseEvent& event)
@@ -742,9 +728,12 @@ void cMain::OnChangeStepRightClicked(wxMouseEvent& event)
 		wxMessageBox("Please select a row to change", "Selection not valid");
 		return;
 	}
-	
-	int row = *rows.begin();
-	
+
+	OnChangeStepInternal(rows, *rows.begin());
+}
+
+void cMain::OnChangeStepInternal(wxArrayInt& rows, int row)
+{
 	auto stepParameters = ExtractStepParameters();
 
 	if (!ValidateStep(row, stepParameters))
@@ -802,25 +791,7 @@ void cMain::OnDeleteStepClicked(wxCommandEvent& event)
 		return;
 	}
 
-	int startRow = rows.at(0);
-	auto steps = DeleteSteps(rows);
-	stack.Push({
-		.row = rows[0],
-		.type = T_DELETE,
-		.rows = steps
-	});
-
-	// The row after the deleted row(s) are selected
-	if (startRow < grid_steps->GetNumberRows())
-	{
-		grid_steps->SelectRow(startRow);
-	}
-	else if(startRow - 1 >= 0)
-	{
-		grid_steps->SelectRow(startRow - 1);
-	}
-
-	no_changes = false;
+	OnDeleteStepInternal(rows, false);
 }
 
 void cMain::OnDeleteStepRightClicked(wxMouseEvent& event)
@@ -834,8 +805,13 @@ void cMain::OnDeleteStepRightClicked(wxMouseEvent& event)
 		return;
 	}
 
+	OnDeleteStepInternal(rows, true);
+}
+
+void cMain::OnDeleteStepInternal(wxArrayInt& rows, bool auto_confirm)
+{
 	int startRow = rows.at(0);
-	auto steps = DeleteSteps(rows, true);
+	auto steps = DeleteSteps(rows, auto_confirm);
 	stack.Push({
 		.row = rows[0],
 		.type = T_DELETE,

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -699,14 +699,15 @@ vector<tuple<int, StepParameters>> cMain::AddStep(int row, StepParameters stepPa
 
 void cMain::OnChangeStepClicked(wxCommandEvent& event)
 {
-	if (!grid_steps->IsSelection() || !grid_steps->GetSelectedRows().begin())
+	event.Skip();
+	wxArrayInt rows = grid_steps->GetSelectedRows();
+	if (!grid_steps->IsSelection() || rows.empty())
 	{
-		wxMessageBox("Please select a row to change", "Selection not valid");
-		event.Skip();
+		wxMessageBox("Please select a row to change", "Selection not valid");	
 		return;
 	}
 
-	int row = *grid_steps->GetSelectedRows().begin();
+	int row = *rows.begin();
 	if (StepGridData[row].StepEnum == e_build)
 	{
 		if (wxMessageBox("The row selected is a build step - are you sure you want to make this change?\nEnsure that you delete associated steps.", "The build step you are changing could be associated with future step", wxICON_WARNING | wxYES_NO, this) != wxYES)
@@ -715,6 +716,35 @@ void cMain::OnChangeStepClicked(wxCommandEvent& event)
 		}
 	}
 
+	auto stepParameters = ExtractStepParameters();
+
+	if (!ValidateStep(row, stepParameters))
+	{
+		return;
+	};
+
+	stack.Push({
+		.row = row,
+		.type = T_MODIFY,
+		.rows = ChangeStep(row, stepParameters)
+	});
+
+	grid_steps->SelectRow(row);
+	no_changes = false;
+}
+
+void cMain::OnChangeStepRightClicked(wxMouseEvent& event)
+{
+	event.Skip();
+	wxArrayInt rows = grid_steps->GetSelectedRows();
+	if (!grid_steps->IsSelection() || rows.empty())
+	{
+		wxMessageBox("Please select a row to change", "Selection not valid");
+		return;
+	}
+	
+	int row = *rows.begin();
+	
 	auto stepParameters = ExtractStepParameters();
 
 	if (!ValidateStep(row, stepParameters))
@@ -755,13 +785,15 @@ vector< tuple<int, StepParameters>> cMain::ChangeStep(int row, StepParameters st
 
 void cMain::OnDeleteStepClicked(wxCommandEvent& event)
 {
-	if (!grid_steps->IsSelection())
+	event.Skip();
+	wxArrayInt rows = grid_steps->GetSelectedRows();
+
+	if (!grid_steps->IsSelection() || rows.IsEmpty())
 	{
 		wxMessageBox("Please select one or more rows to delete", "Selection not valid");
 		return;
 	}
 
-	wxArrayInt rows = grid_steps->GetSelectedRows();
 	if (wxMessageBox(
 		rows == 1 ? "Are you sure you want to delete this step?" : "Are you sure you want to delete these steps?",
 		rows == 1 ? "Delete step" : "Delete steps", 
@@ -769,6 +801,7 @@ void cMain::OnDeleteStepClicked(wxCommandEvent& event)
 	{
 		return;
 	}
+
 	int startRow = rows.at(0);
 	auto steps = DeleteSteps(rows);
 	stack.Push({
@@ -788,7 +821,38 @@ void cMain::OnDeleteStepClicked(wxCommandEvent& event)
 	}
 
 	no_changes = false;
+}
+
+void cMain::OnDeleteStepRightClicked(wxMouseEvent& event)
+{
 	event.Skip();
+	wxArrayInt rows = grid_steps->GetSelectedRows();
+
+	if (!grid_steps->IsSelection() || rows.IsEmpty())
+	{
+		wxMessageBox("Please select one or more rows to delete", "Selection not valid");
+		return;
+	}
+
+	int startRow = rows.at(0);
+	auto steps = DeleteSteps(rows, true);
+	stack.Push({
+		.row = rows[0],
+		.type = T_DELETE,
+		.rows = steps
+	});
+
+	// The row after the deleted row(s) are selected
+	if (startRow < grid_steps->GetNumberRows())
+	{
+		grid_steps->SelectRow(startRow);
+	}
+	else if (startRow - 1 >= 0)
+	{
+		grid_steps->SelectRow(startRow - 1);
+	}
+
+	no_changes = false;
 }
 
 vector< tuple<int, StepParameters>> cMain::DeleteSteps(wxArrayInt steps, bool auto_confirmed)
@@ -950,11 +1014,12 @@ void cMain::OnStepsGridDoubleRightClick(wxGridEvent& event)
 
 void cMain::OnStepsGridRangeSelect(wxGridRangeSelectEvent& event)
 {
+	event.Skip();
 	wxArrayInt rows = grid_steps->GetSelectedRows();
 	if (rows.empty()){ //prevents a crash due to somehow selecting zero rows??
-		event.Skip();
 		return;
 	}
+
 	wxColour colour = grid_steps->GetCellBackgroundColour(rows[0], 1); //retrieve the colour of the first selected element
 	step_colour_picker->SetColour(colour);
 
@@ -966,6 +1031,7 @@ void cMain::OnStepsGridRangeSelect(wxGridRangeSelectEvent& event)
 		modifier_skip_checkbox->Show();
 		modifier_skip_button->Hide();
 		sizer_skip->Layout();
+		btn_change_step->Enable();
 	}
 	else
 	{
@@ -975,10 +1041,8 @@ void cMain::OnStepsGridRangeSelect(wxGridRangeSelectEvent& event)
 		modifier_skip_checkbox->Hide();
 		modifier_skip_button->Show();
 		sizer_skip->Layout();
-
-	}
-	
-	event.Skip();
+		btn_change_step->Disable();
+	}	
 }
 
 void cMain::OnStepColourPickerColourChanged(wxColourPickerEvent& event)
@@ -1663,7 +1727,19 @@ void cMain::OnMenuAutoCloseSaveAsClicked(wxCommandEvent& event)
 
 void cMain::OnChangeMenuSelected(wxCommandEvent& event)
 {
-	OnChangeStepClicked(event);
+	if (btn_change_step->IsEnabled())
+		OnChangeStepClicked(event);
+	else
+		wxMessageBox("Please select 1 row to change", "Selection not valid");
+	event.Skip();
+}
+
+void cMain::OnChangeAltMenuSelected(wxCommandEvent& event)
+{
+	if (btn_change_step->IsEnabled())
+		OnChangeStepClicked(event);
+	else
+		wxMessageBox("Please select 1 row to change", "Selection not valid");
 	event.Skip();
 }
 
@@ -1673,9 +1749,23 @@ void cMain::OnDeleteMenuSelected(wxCommandEvent& event)
 	event.Skip();
 }
 
+void cMain::OnDeleteAltMenuSelected(wxCommandEvent& event)
+{
+	auto new_event = wxMouseEvent();
+	OnDeleteStepRightClicked(new_event);
+	event.Skip();
+}
+
 void cMain::OnMoveUpMenuSelected(wxCommandEvent& event)
 {
 	OnMoveUpClicked(event);
+	event.Skip();
+}
+
+void cMain::OnMoveUpAltMenuSelected(wxCommandEvent& event)
+{
+	auto new_event = wxMouseEvent();
+	OnMoveUpFiveClicked(new_event);
 	event.Skip();
 }
 
@@ -1685,9 +1775,29 @@ void cMain::OnMoveDownMenuSelected(wxCommandEvent& event)
 	event.Skip();
 }
 
+void cMain::OnMoveDownAltMenuSelected(wxCommandEvent& event)
+{
+	auto new_event = wxMouseEvent();
+	OnMoveDownFiveClicked(new_event);
+	event.Skip();
+}
+
+void cMain::OnSearchMenuSelected(wxCommandEvent& event)
+{
+	step_search_ctrl->SetFocus();
+	event.Skip();
+}
+
 void cMain::OnAddMenuSelected(wxCommandEvent& event)
 {
 	OnAddStepClicked(event);
+	event.Skip();
+}
+
+void cMain::OnAddAltMenuSelected(wxCommandEvent& event)
+{
+	auto new_event = wxMouseEvent();
+	OnAddStepRightClicked(new_event);
 	event.Skip();
 }
 

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -154,8 +154,10 @@ protected:
 	void OnAddStepRightClicked(wxMouseEvent & event);
 	void OnChangeStepClicked(wxCommandEvent& event);
 	void OnChangeStepRightClicked(wxMouseEvent& event);
+	void OnChangeStepInternal(wxArrayInt& rows, int row);
 	void OnDeleteStepClicked(wxCommandEvent& event);
 	void OnDeleteStepRightClicked(wxMouseEvent& event);
+	void OnDeleteStepInternal(wxArrayInt& rows, bool auto_confirm);
 	void OnMoveUpClicked(wxCommandEvent& event);
 	void OnMoveDownClicked(wxCommandEvent& event);
 	void OnMoveUpFiveClicked(wxMouseEvent& event);

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -62,33 +62,51 @@ protected:
 	void OnChooseLocation(wxCommandEvent& event);
 	void OnGenerateScript(wxCommandEvent& event);
 
-	void OnChangeShortcutMenuSelected(wxCommandEvent & event);
+	// Step types menu
 	void OnWalkMenuSelected(wxCommandEvent& event);
+	void OnCraftMenuSelected(wxCommandEvent& event);
+	void OnTechMenuSelected(wxCommandEvent& event);
+	void OnIdleMenuSelected(wxCommandEvent& event);
+	void OnPickUpMenuSelected(wxCommandEvent& event);
+	void OnDropMenuSelected(wxCommandEvent& event);
+	void OnCancelCraftingMenuSelected(wxCommandEvent& event);
 	void OnMineMenuSelected(wxCommandEvent& event);
-	void OnGameSpeedMenuSelected(wxCommandEvent& event);
-	void OnBuildMenuSelected(wxCommandEvent& event);
+	void OnThrowMenuSelected(wxCommandEvent& event);
+	void OnShootMenuSelected(wxCommandEvent& event);
+
 	void OnTakeMenuSelected(wxCommandEvent& event);
 	void OnPutMenuSelected(wxCommandEvent& event);
-	void OnCraftMenuSelected(wxCommandEvent& event);
-	void OnCancelCraftingMenuSelected(wxCommandEvent& event);
+	void OnBuildMenuSelected(wxCommandEvent& event);
 	void OnRecipeMenuChosen(wxCommandEvent& event);
-	void OnRotateMenuSelected(wxCommandEvent& event);
-	void OnAddMenuSelected(wxCommandEvent& event);
-	void OnTechMenuSelected(wxCommandEvent& event);
-	void OnChangeMenuSelected(wxCommandEvent& event);
-	void OnDeleteMenuSelected(wxCommandEvent& event);
-	void OnMoveUpMenuSelected(wxCommandEvent& event);
-	void OnMoveDownMenuSelected(wxCommandEvent& event);
-	void OnPriorityMenuSelected(wxCommandEvent& event);
 	void OnLimitMenuSelected(wxCommandEvent& event);
 	void OnFilterMenuSelected(wxCommandEvent& event);
-	void OnStopMenuSelected(wxCommandEvent& event);
-	void OnIdleMenuSelected(wxCommandEvent& event);
+	void OnPriorityMenuSelected(wxCommandEvent& event);
 	void OnLaunchMenuSelected(wxCommandEvent& event);
-	void OnDropMenuSelected(wxCommandEvent& event);
-	void OnPickUpMenuSelected(wxCommandEvent& event);
-	void OnSaveMenuSelected(wxCommandEvent& event);
+	void OnRotateMenuSelected(wxCommandEvent& event);
+
+	void OnGameSpeedMenuSelected(wxCommandEvent& event);
 	void OnPauseMenuSelected(wxCommandEvent& event);
+	void OnStopMenuSelected(wxCommandEvent& event);
+	void OnSaveMenuSelected(wxCommandEvent& event);
+	void OnNeverIdleMenuSelected(wxCommandEvent& event);
+	void OnKeepWalkingMenuSelected(wxCommandEvent& event);
+	void OnKeepOnPathMenuSelected(wxCommandEvent& event);
+	void OnKeepCraftingMenuSelected(wxCommandEvent& event);
+
+	// Shortcut menu
+	void OnChangeShortcutMenuSelected(wxCommandEvent& event);
+
+	void OnAddMenuSelected(wxCommandEvent& event);
+	void OnAddAltMenuSelected(wxCommandEvent& event);
+	void OnChangeMenuSelected(wxCommandEvent& event);
+	void OnChangeAltMenuSelected(wxCommandEvent& event);
+	void OnDeleteMenuSelected(wxCommandEvent& event);
+	void OnDeleteAltMenuSelected(wxCommandEvent& event);
+	void OnMoveUpMenuSelected(wxCommandEvent& event);
+	void OnMoveUpAltMenuSelected(wxCommandEvent& event);
+	void OnMoveDownMenuSelected(wxCommandEvent& event);
+	void OnMoveDownAltMenuSelected(wxCommandEvent& event);
+	void OnSearchMenuSelected(wxCommandEvent& event);
 
 	// Auto-close menu items
 	void OnMenuAutoCloseGenerateScriptClicked(wxCommandEvent& event);
@@ -135,7 +153,9 @@ protected:
 	void OnAddStepClicked(wxCommandEvent& event);
 	void OnAddStepRightClicked(wxMouseEvent & event);
 	void OnChangeStepClicked(wxCommandEvent& event);
+	void OnChangeStepRightClicked(wxMouseEvent& event);
 	void OnDeleteStepClicked(wxCommandEvent& event);
+	void OnDeleteStepRightClicked(wxMouseEvent& event);
 	void OnMoveUpClicked(wxCommandEvent& event);
 	void OnMoveDownClicked(wxCommandEvent& event);
 	void OnMoveUpFiveClicked(wxMouseEvent& event);


### PR DESCRIPTION
- Removed building_orientation from StepType:Priority.
- Added lookup array matching StepType to parameter_choices
- Refactored cMain::UpdateParameters

**UpdateParameters** has grown way to large. This should help reduce it's size. I have used the system of parameter_choices to find out which control elements that should be updated.
I can reduce the size of the function further. However some of On___SelectMenu have more code in them so i would need to put the functions into a lookup table. I don't think it would be worth it currently.

It looks a bit silly to have a switch where all but one case seemingly does the same, but it should at least be easier to work with.

I removed building_orientation from Priority as the value isn't relevant. And the field is being used for priority. Can this cause issues?

This is built on #282 to get the select menu functions.