### PR TITLE
Change color of steps

### DIFF
--- a/src/Factorio-TAS-Generator.vcxproj
+++ b/src/Factorio-TAS-Generator.vcxproj
@@ -179,6 +179,7 @@
     <ClCompile Include="StepParameters.cpp" />
     <ClCompile Include="SearchUtil.cpp" />
     <ClCompile Include="StepNameToEnum.cpp" />
+    <ClCompile Include="SteptypeColour.cpp" />
     <ClCompile Include="TypePanel.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -206,6 +207,7 @@
     <ClInclude Include="GridEntry.h" />
     <ClInclude Include="StepParameters.h" />
     <ClInclude Include="Settings.h" />
+    <ClInclude Include="SteptypeColour.h" />
     <ClInclude Include="TasFileConstants.h" />
     <ClInclude Include="TypePanel.h" />
     <ClInclude Include="utils.h" />

--- a/src/Factorio-TAS-Generator.vcxproj.filters
+++ b/src/Factorio-TAS-Generator.vcxproj.filters
@@ -25,6 +25,7 @@
     <ClCompile Include="ShortcutChanger.cpp" />
     <ClCompile Include="ImportStepsPanel.cpp" />
     <ClCompile Include="CommandStack.cpp" />
+    <ClCompile Include="SteptypeColour.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cApp.h" />
@@ -70,6 +71,7 @@
     <ClInclude Include="Priority.h" />
     <ClInclude Include="TasFileConstants.h" />
     <ClInclude Include="CommandStack.h" />
+    <ClInclude Include="SteptypeColour.h" />
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\Lua Files\control.lua">
@@ -79,9 +81,6 @@
       <Filter>lua</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="..\Lua Files\settings.lua">
-      <Filter>lua</Filter>
-    </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\settings-updates.lua">
       <Filter>lua</Filter>
     </CopyFileToFolders>
   </ItemGroup>
@@ -113,5 +112,8 @@
     <ResourceCompile Include="Factorio-TAS-Generator.rc">
       <Filter>misc</Filter>
     </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\Lua Files\goals.lua" />
   </ItemGroup>
 </Project>

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -10574,7 +10574,7 @@
                         <property name="floatable">1</property>
                         <property name="font"></property>
                         <property name="gripper">0</property>
-                        <property name="hidden">0</property>
+                        <property name="hidden">1</property>
                         <property name="id">wxID_ANY</property>
                         <property name="label">label</property>
                         <property name="markup">0</property>
@@ -10644,7 +10644,7 @@
                         <property name="maximum_size">1200,1000</property>
                         <property name="min_size"></property>
                         <property name="minimize_button">0</property>
-                        <property name="minimum_size">700,500</property>
+                        <property name="minimum_size">430,200</property>
                         <property name="moveable">1</property>
                         <property name="name">steptype_colour_book</property>
                         <property name="pane_border">1</property>
@@ -10655,7 +10655,7 @@
                         <property name="pos"></property>
                         <property name="resize">Resizable</property>
                         <property name="show">1</property>
-                        <property name="size">900,700</property>
+                        <property name="size">600,600</property>
                         <property name="style">wxLB_DEFAULT</property>
                         <property name="subclass">; ; forward_declare</property>
                         <property name="toolbar_pane">0</property>

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -193,6 +193,24 @@
                     <property name="label">Step types</property>
                     <property name="name">menu_steptypes</property>
                     <property name="permission">protected</property>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Change colours</property>
+                        <property name="name">steptypecolour_changer</property>
+                        <property name="permission">protected</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnChangeSteptypeColoursMenuSelected</event>
+                    </object>
+                    <object class="separator" expanded="1">
+                        <property name="name">steptype_colour_seperator</property>
+                        <property name="permission">none</property>
+                    </object>
                     <object class="wxMenuItem" expanded="0">
                         <property name="bitmap"></property>
                         <property name="checked">0</property>
@@ -10481,6 +10499,411 @@
                                             <property name="window_name"></property>
                                             <property name="window_style"></property>
                                             <event name="OnButtonClick">GenerateScriptOnClick</event>
+                                        </object>
+                                    </object>
+                                </object>
+                            </object>
+                        </object>
+                    </object>
+                </object>
+            </object>
+        </object>
+        <object class="Dialog" expanded="1">
+            <property name="aui_managed">0</property>
+            <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
+            <property name="bg"></property>
+            <property name="center">wxBOTH</property>
+            <property name="context_help"></property>
+            <property name="context_menu">1</property>
+            <property name="drag_accept_files">0</property>
+            <property name="enabled">1</property>
+            <property name="event_handler">impl_virtual</property>
+            <property name="extra_style"></property>
+            <property name="fg"></property>
+            <property name="font"></property>
+            <property name="hidden">0</property>
+            <property name="id">wxID_ANY</property>
+            <property name="maximum_size"></property>
+            <property name="minimum_size"></property>
+            <property name="name">StepTypeColoursDialog</property>
+            <property name="pos"></property>
+            <property name="size"></property>
+            <property name="style">wxDEFAULT_DIALOG_STYLE</property>
+            <property name="subclass">; ; forward_declare</property>
+            <property name="title">Step type colours</property>
+            <property name="tooltip"></property>
+            <property name="two_step_creation">0</property>
+            <property name="window_extra_style"></property>
+            <property name="window_name"></property>
+            <property name="window_style">wxBORDER_RAISED|wxTAB_TRAVERSAL</property>
+            <event name="OnClose">OnCloseStepTypeColoursChanger</event>
+            <event name="OnInitDialog">OnInitStepTypeColoursDialog</event>
+            <object class="wxBoxSizer" expanded="1">
+                <property name="minimum_size"></property>
+                <property name="name">StepTypeColoursDialog_sizer</property>
+                <property name="orient">wxVERTICAL</property>
+                <property name="permission">protected</property>
+                <object class="sizeritem" expanded="1">
+                    <property name="border">5</property>
+                    <property name="flag">wxALL</property>
+                    <property name="proportion">0</property>
+                    <object class="wxStaticText" expanded="1">
+                        <property name="BottomDockable">1</property>
+                        <property name="LeftDockable">1</property>
+                        <property name="RightDockable">1</property>
+                        <property name="TopDockable">1</property>
+                        <property name="aui_layer"></property>
+                        <property name="aui_name"></property>
+                        <property name="aui_position"></property>
+                        <property name="aui_row"></property>
+                        <property name="best_size"></property>
+                        <property name="bg"></property>
+                        <property name="caption"></property>
+                        <property name="caption_visible">1</property>
+                        <property name="center_pane">0</property>
+                        <property name="close_button">1</property>
+                        <property name="context_help"></property>
+                        <property name="context_menu">1</property>
+                        <property name="default_pane">0</property>
+                        <property name="dock">Dock</property>
+                        <property name="dock_fixed">0</property>
+                        <property name="docking">Left</property>
+                        <property name="drag_accept_files">0</property>
+                        <property name="enabled">1</property>
+                        <property name="fg"></property>
+                        <property name="floatable">1</property>
+                        <property name="font"></property>
+                        <property name="gripper">0</property>
+                        <property name="hidden">0</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="label">label</property>
+                        <property name="markup">0</property>
+                        <property name="max_size"></property>
+                        <property name="maximize_button">0</property>
+                        <property name="maximum_size"></property>
+                        <property name="min_size"></property>
+                        <property name="minimize_button">0</property>
+                        <property name="minimum_size"></property>
+                        <property name="moveable">1</property>
+                        <property name="name">steptype_colour_label</property>
+                        <property name="pane_border">1</property>
+                        <property name="pane_position"></property>
+                        <property name="pane_size"></property>
+                        <property name="permission">protected</property>
+                        <property name="pin_button">1</property>
+                        <property name="pos"></property>
+                        <property name="resize">Resizable</property>
+                        <property name="show">1</property>
+                        <property name="size"></property>
+                        <property name="style"></property>
+                        <property name="subclass">; ; forward_declare</property>
+                        <property name="toolbar_pane">0</property>
+                        <property name="tooltip"></property>
+                        <property name="window_extra_style"></property>
+                        <property name="window_name"></property>
+                        <property name="window_style"></property>
+                        <property name="wrap">-1</property>
+                    </object>
+                </object>
+                <object class="sizeritem" expanded="1">
+                    <property name="border">5</property>
+                    <property name="flag">wxEXPAND | wxALL</property>
+                    <property name="proportion">1</property>
+                    <object class="wxListbook" expanded="1">
+                        <property name="BottomDockable">1</property>
+                        <property name="LeftDockable">1</property>
+                        <property name="RightDockable">1</property>
+                        <property name="TopDockable">1</property>
+                        <property name="aui_layer"></property>
+                        <property name="aui_name"></property>
+                        <property name="aui_position"></property>
+                        <property name="aui_row"></property>
+                        <property name="best_size"></property>
+                        <property name="bg"></property>
+                        <property name="bitmapsize"></property>
+                        <property name="caption"></property>
+                        <property name="caption_visible">1</property>
+                        <property name="center_pane">0</property>
+                        <property name="close_button">1</property>
+                        <property name="context_help"></property>
+                        <property name="context_menu">1</property>
+                        <property name="default_pane">0</property>
+                        <property name="dock">Dock</property>
+                        <property name="dock_fixed">0</property>
+                        <property name="docking">Left</property>
+                        <property name="drag_accept_files">0</property>
+                        <property name="enabled">1</property>
+                        <property name="fg"></property>
+                        <property name="floatable">1</property>
+                        <property name="font"></property>
+                        <property name="gripper">0</property>
+                        <property name="hidden">0</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="max_size"></property>
+                        <property name="maximize_button">0</property>
+                        <property name="maximum_size">1200,1000</property>
+                        <property name="min_size"></property>
+                        <property name="minimize_button">0</property>
+                        <property name="minimum_size">700,500</property>
+                        <property name="moveable">1</property>
+                        <property name="name">steptype_colour_book</property>
+                        <property name="pane_border">1</property>
+                        <property name="pane_position"></property>
+                        <property name="pane_size"></property>
+                        <property name="permission">protected</property>
+                        <property name="pin_button">1</property>
+                        <property name="pos"></property>
+                        <property name="resize">Resizable</property>
+                        <property name="show">1</property>
+                        <property name="size">900,700</property>
+                        <property name="style">wxLB_DEFAULT</property>
+                        <property name="subclass">; ; forward_declare</property>
+                        <property name="toolbar_pane">0</property>
+                        <property name="tooltip"></property>
+                        <property name="window_extra_style"></property>
+                        <property name="window_name"></property>
+                        <property name="window_style"></property>
+                        <object class="listbookpage" expanded="1">
+                            <property name="bitmap"></property>
+                            <property name="label">Character</property>
+                            <property name="select">0</property>
+                            <object class="wxPanel" expanded="1">
+                                <property name="BottomDockable">1</property>
+                                <property name="LeftDockable">1</property>
+                                <property name="RightDockable">1</property>
+                                <property name="TopDockable">1</property>
+                                <property name="aui_layer"></property>
+                                <property name="aui_name"></property>
+                                <property name="aui_position"></property>
+                                <property name="aui_row"></property>
+                                <property name="best_size"></property>
+                                <property name="bg"></property>
+                                <property name="caption"></property>
+                                <property name="caption_visible">1</property>
+                                <property name="center_pane">0</property>
+                                <property name="close_button">1</property>
+                                <property name="context_help"></property>
+                                <property name="context_menu">1</property>
+                                <property name="default_pane">0</property>
+                                <property name="dock">Dock</property>
+                                <property name="dock_fixed">0</property>
+                                <property name="docking">Left</property>
+                                <property name="drag_accept_files">0</property>
+                                <property name="enabled">1</property>
+                                <property name="fg"></property>
+                                <property name="floatable">1</property>
+                                <property name="font"></property>
+                                <property name="gripper">0</property>
+                                <property name="hidden">0</property>
+                                <property name="id">wxID_ANY</property>
+                                <property name="max_size"></property>
+                                <property name="maximize_button">0</property>
+                                <property name="maximum_size"></property>
+                                <property name="min_size"></property>
+                                <property name="minimize_button">0</property>
+                                <property name="minimum_size"></property>
+                                <property name="moveable">1</property>
+                                <property name="name">steptype_colour_character_panel</property>
+                                <property name="pane_border">1</property>
+                                <property name="pane_position"></property>
+                                <property name="pane_size"></property>
+                                <property name="permission">protected</property>
+                                <property name="pin_button">1</property>
+                                <property name="pos"></property>
+                                <property name="resize">Resizable</property>
+                                <property name="show">1</property>
+                                <property name="size"></property>
+                                <property name="subclass">; ; forward_declare</property>
+                                <property name="toolbar_pane">0</property>
+                                <property name="tooltip"></property>
+                                <property name="window_extra_style"></property>
+                                <property name="window_name"></property>
+                                <property name="window_style">wxTAB_TRAVERSAL</property>
+                                <object class="wxBoxSizer" expanded="1">
+                                    <property name="minimum_size"></property>
+                                    <property name="name">stc_character_sizer</property>
+                                    <property name="orient">wxVERTICAL</property>
+                                    <property name="permission">protected</property>
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag">wxEXPAND</property>
+                                        <property name="proportion">1</property>
+                                        <object class="wxFlexGridSizer" expanded="1">
+                                            <property name="cols">2</property>
+                                            <property name="flexible_direction">wxBOTH</property>
+                                            <property name="growablecols"></property>
+                                            <property name="growablerows"></property>
+                                            <property name="hgap">0</property>
+                                            <property name="minimum_size"></property>
+                                            <property name="name">stc_character_grid_sizer</property>
+                                            <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
+                                            <property name="permission">protected</property>
+                                            <property name="rows">0</property>
+                                            <property name="vgap">0</property>
+                                        </object>
+                                    </object>
+                                </object>
+                            </object>
+                        </object>
+                        <object class="listbookpage" expanded="1">
+                            <property name="bitmap"></property>
+                            <property name="label">Building</property>
+                            <property name="select">0</property>
+                            <object class="wxPanel" expanded="1">
+                                <property name="BottomDockable">1</property>
+                                <property name="LeftDockable">1</property>
+                                <property name="RightDockable">1</property>
+                                <property name="TopDockable">1</property>
+                                <property name="aui_layer"></property>
+                                <property name="aui_name"></property>
+                                <property name="aui_position"></property>
+                                <property name="aui_row"></property>
+                                <property name="best_size"></property>
+                                <property name="bg"></property>
+                                <property name="caption"></property>
+                                <property name="caption_visible">1</property>
+                                <property name="center_pane">0</property>
+                                <property name="close_button">1</property>
+                                <property name="context_help"></property>
+                                <property name="context_menu">1</property>
+                                <property name="default_pane">0</property>
+                                <property name="dock">Dock</property>
+                                <property name="dock_fixed">0</property>
+                                <property name="docking">Left</property>
+                                <property name="drag_accept_files">0</property>
+                                <property name="enabled">1</property>
+                                <property name="fg"></property>
+                                <property name="floatable">1</property>
+                                <property name="font"></property>
+                                <property name="gripper">0</property>
+                                <property name="hidden">0</property>
+                                <property name="id">wxID_ANY</property>
+                                <property name="max_size"></property>
+                                <property name="maximize_button">0</property>
+                                <property name="maximum_size"></property>
+                                <property name="min_size"></property>
+                                <property name="minimize_button">0</property>
+                                <property name="minimum_size"></property>
+                                <property name="moveable">1</property>
+                                <property name="name">steptype_colour_building_panel</property>
+                                <property name="pane_border">1</property>
+                                <property name="pane_position"></property>
+                                <property name="pane_size"></property>
+                                <property name="permission">protected</property>
+                                <property name="pin_button">1</property>
+                                <property name="pos"></property>
+                                <property name="resize">Resizable</property>
+                                <property name="show">1</property>
+                                <property name="size"></property>
+                                <property name="subclass">; ; forward_declare</property>
+                                <property name="toolbar_pane">0</property>
+                                <property name="tooltip"></property>
+                                <property name="window_extra_style"></property>
+                                <property name="window_name"></property>
+                                <property name="window_style">wxTAB_TRAVERSAL</property>
+                                <object class="wxBoxSizer" expanded="1">
+                                    <property name="minimum_size"></property>
+                                    <property name="name">stc_building_sizer</property>
+                                    <property name="orient">wxVERTICAL</property>
+                                    <property name="permission">protected</property>
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag">wxEXPAND</property>
+                                        <property name="proportion">1</property>
+                                        <object class="wxFlexGridSizer" expanded="1">
+                                            <property name="cols">2</property>
+                                            <property name="flexible_direction">wxBOTH</property>
+                                            <property name="growablecols"></property>
+                                            <property name="growablerows"></property>
+                                            <property name="hgap">0</property>
+                                            <property name="minimum_size"></property>
+                                            <property name="name">stc_building_grid_sizer</property>
+                                            <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
+                                            <property name="permission">protected</property>
+                                            <property name="rows">0</property>
+                                            <property name="vgap">0</property>
+                                        </object>
+                                    </object>
+                                </object>
+                            </object>
+                        </object>
+                        <object class="listbookpage" expanded="1">
+                            <property name="bitmap"></property>
+                            <property name="label">Game</property>
+                            <property name="select">0</property>
+                            <object class="wxPanel" expanded="1">
+                                <property name="BottomDockable">1</property>
+                                <property name="LeftDockable">1</property>
+                                <property name="RightDockable">1</property>
+                                <property name="TopDockable">1</property>
+                                <property name="aui_layer"></property>
+                                <property name="aui_name"></property>
+                                <property name="aui_position"></property>
+                                <property name="aui_row"></property>
+                                <property name="best_size"></property>
+                                <property name="bg"></property>
+                                <property name="caption"></property>
+                                <property name="caption_visible">1</property>
+                                <property name="center_pane">0</property>
+                                <property name="close_button">1</property>
+                                <property name="context_help"></property>
+                                <property name="context_menu">1</property>
+                                <property name="default_pane">0</property>
+                                <property name="dock">Dock</property>
+                                <property name="dock_fixed">0</property>
+                                <property name="docking">Left</property>
+                                <property name="drag_accept_files">0</property>
+                                <property name="enabled">1</property>
+                                <property name="fg"></property>
+                                <property name="floatable">1</property>
+                                <property name="font"></property>
+                                <property name="gripper">0</property>
+                                <property name="hidden">0</property>
+                                <property name="id">wxID_ANY</property>
+                                <property name="max_size"></property>
+                                <property name="maximize_button">0</property>
+                                <property name="maximum_size"></property>
+                                <property name="min_size"></property>
+                                <property name="minimize_button">0</property>
+                                <property name="minimum_size"></property>
+                                <property name="moveable">1</property>
+                                <property name="name">steptype_colour_game_panel</property>
+                                <property name="pane_border">1</property>
+                                <property name="pane_position"></property>
+                                <property name="pane_size"></property>
+                                <property name="permission">protected</property>
+                                <property name="pin_button">1</property>
+                                <property name="pos"></property>
+                                <property name="resize">Resizable</property>
+                                <property name="show">1</property>
+                                <property name="size"></property>
+                                <property name="subclass">; ; forward_declare</property>
+                                <property name="toolbar_pane">0</property>
+                                <property name="tooltip"></property>
+                                <property name="window_extra_style"></property>
+                                <property name="window_name"></property>
+                                <property name="window_style">wxTAB_TRAVERSAL</property>
+                                <object class="wxBoxSizer" expanded="1">
+                                    <property name="minimum_size"></property>
+                                    <property name="name">stc_game_sizer</property>
+                                    <property name="orient">wxVERTICAL</property>
+                                    <property name="permission">protected</property>
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag">wxEXPAND</property>
+                                        <property name="proportion">1</property>
+                                        <object class="wxFlexGridSizer" expanded="1">
+                                            <property name="cols">2</property>
+                                            <property name="flexible_direction">wxBOTH</property>
+                                            <property name="growablecols"></property>
+                                            <property name="growablerows"></property>
+                                            <property name="hgap">0</property>
+                                            <property name="minimum_size"></property>
+                                            <property name="name">stc_game_grid_sizer</property>
+                                            <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
+                                            <property name="permission">protected</property>
+                                            <property name="rows">0</property>
+                                            <property name="vgap">0</property>
                                         </object>
                                     </object>
                                 </object>

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -51,6 +51,11 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	main_menubar->Append( menu_script, wxT("Script") );
 
 	menu_steptypes = new wxMenu();
+	steptypecolour_changer = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Change colours") ) , wxEmptyString, wxITEM_NORMAL );
+	menu_steptypes->Append( steptypecolour_changer );
+
+	menu_steptypes->AppendSeparator();
+
 	wxMenuItem* shortcut_walk;
 	shortcut_walk = new wxMenuItem( menu_steptypes, wxID_ANY, wxString( wxT("Walk") ) + wxT('\t') + wxT("Ctrl+2"), wxEmptyString, wxITEM_NORMAL );
 	menu_steptypes->Append( shortcut_walk );
@@ -1424,6 +1429,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	menu_file->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuExit ), this, menu_file_exit->GetId());
 	menu_script->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnChooseLocation ), this, menu_script_choose_location->GetId());
 	menu_script->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnGenerateScript ), this, menu_script_generate_script->GetId());
+	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnChangeSteptypeColoursMenuSelected ), this, steptypecolour_changer->GetId());
 	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnWalkMenuSelected ), this, shortcut_walk->GetId());
 	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnCraftMenuSelected ), this, shortcut_craft->GetId());
 	menu_steptypes->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnTechMenuSelected ), this, shortcut_tech->GetId());
@@ -1846,5 +1852,96 @@ BaseForDialogProgress::~BaseForDialogProgress()
 {
 	// Disconnect Events
 	btn_dialog_progress_done->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( BaseForDialogProgress::GenerateScriptOnClick ), NULL, this );
+
+}
+
+StepTypeColoursDialog::StepTypeColoursDialog( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
+{
+	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+
+	StepTypeColoursDialog_sizer = new wxBoxSizer( wxVERTICAL );
+
+	steptype_colour_label = new wxStaticText( this, wxID_ANY, wxT("label"), wxDefaultPosition, wxDefaultSize, 0 );
+	steptype_colour_label->Wrap( -1 );
+	StepTypeColoursDialog_sizer->Add( steptype_colour_label, 0, wxALL, 5 );
+
+	steptype_colour_book = new wxListbook( this, wxID_ANY, wxDefaultPosition, wxSize( 900,700 ), wxLB_DEFAULT );
+	steptype_colour_book->SetMinSize( wxSize( 700,500 ) );
+	steptype_colour_book->SetMaxSize( wxSize( 1200,1000 ) );
+
+	steptype_colour_character_panel = new wxPanel( steptype_colour_book, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	stc_character_sizer = new wxBoxSizer( wxVERTICAL );
+
+	stc_character_grid_sizer = new wxFlexGridSizer( 0, 2, 0, 0 );
+	stc_character_grid_sizer->SetFlexibleDirection( wxBOTH );
+	stc_character_grid_sizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+
+
+	stc_character_sizer->Add( stc_character_grid_sizer, 1, wxEXPAND, 5 );
+
+
+	steptype_colour_character_panel->SetSizer( stc_character_sizer );
+	steptype_colour_character_panel->Layout();
+	stc_character_sizer->Fit( steptype_colour_character_panel );
+	steptype_colour_book->AddPage( steptype_colour_character_panel, wxT("Character"), false );
+	steptype_colour_building_panel = new wxPanel( steptype_colour_book, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	stc_building_sizer = new wxBoxSizer( wxVERTICAL );
+
+	stc_building_grid_sizer = new wxFlexGridSizer( 0, 2, 0, 0 );
+	stc_building_grid_sizer->SetFlexibleDirection( wxBOTH );
+	stc_building_grid_sizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+
+
+	stc_building_sizer->Add( stc_building_grid_sizer, 1, wxEXPAND, 5 );
+
+
+	steptype_colour_building_panel->SetSizer( stc_building_sizer );
+	steptype_colour_building_panel->Layout();
+	stc_building_sizer->Fit( steptype_colour_building_panel );
+	steptype_colour_book->AddPage( steptype_colour_building_panel, wxT("Building"), false );
+	steptype_colour_game_panel = new wxPanel( steptype_colour_book, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	stc_game_sizer = new wxBoxSizer( wxVERTICAL );
+
+	stc_game_grid_sizer = new wxFlexGridSizer( 0, 2, 0, 0 );
+	stc_game_grid_sizer->SetFlexibleDirection( wxBOTH );
+	stc_game_grid_sizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+
+
+	stc_game_sizer->Add( stc_game_grid_sizer, 1, wxEXPAND, 5 );
+
+
+	steptype_colour_game_panel->SetSizer( stc_game_sizer );
+	steptype_colour_game_panel->Layout();
+	stc_game_sizer->Fit( steptype_colour_game_panel );
+	steptype_colour_book->AddPage( steptype_colour_game_panel, wxT("Game"), false );
+	#ifdef __WXGTK__ // Small icon style not supported in GTK
+	wxListView* steptype_colour_bookListView = steptype_colour_book->GetListView();
+	long steptype_colour_bookFlags = steptype_colour_bookListView->GetWindowStyleFlag();
+	if( steptype_colour_bookFlags & wxLC_SMALL_ICON )
+	{
+		steptype_colour_bookFlags = ( steptype_colour_bookFlags & ~wxLC_SMALL_ICON ) | wxLC_ICON;
+	}
+	steptype_colour_bookListView->SetWindowStyleFlag( steptype_colour_bookFlags );
+	#endif
+
+	StepTypeColoursDialog_sizer->Add( steptype_colour_book, 1, wxEXPAND | wxALL, 5 );
+
+
+	this->SetSizer( StepTypeColoursDialog_sizer );
+	this->Layout();
+	StepTypeColoursDialog_sizer->Fit( this );
+
+	this->Centre( wxBOTH );
+
+	// Connect Events
+	this->Connect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( StepTypeColoursDialog::OnCloseStepTypeColoursChanger ) );
+	this->Connect( wxEVT_INIT_DIALOG, wxInitDialogEventHandler( StepTypeColoursDialog::OnInitStepTypeColoursDialog ) );
+}
+
+StepTypeColoursDialog::~StepTypeColoursDialog()
+{
+	// Disconnect Events
+	this->Disconnect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( StepTypeColoursDialog::OnCloseStepTypeColoursChanger ) );
+	this->Disconnect( wxEVT_INIT_DIALOG, wxInitDialogEventHandler( StepTypeColoursDialog::OnInitStepTypeColoursDialog ) );
 
 }

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -1863,10 +1863,12 @@ StepTypeColoursDialog::StepTypeColoursDialog( wxWindow* parent, wxWindowID id, c
 
 	steptype_colour_label = new wxStaticText( this, wxID_ANY, wxT("label"), wxDefaultPosition, wxDefaultSize, 0 );
 	steptype_colour_label->Wrap( -1 );
+	steptype_colour_label->Hide();
+
 	StepTypeColoursDialog_sizer->Add( steptype_colour_label, 0, wxALL, 5 );
 
-	steptype_colour_book = new wxListbook( this, wxID_ANY, wxDefaultPosition, wxSize( 900,700 ), wxLB_DEFAULT );
-	steptype_colour_book->SetMinSize( wxSize( 700,500 ) );
+	steptype_colour_book = new wxListbook( this, wxID_ANY, wxDefaultPosition, wxSize( 600,600 ), wxLB_DEFAULT );
+	steptype_colour_book->SetMinSize( wxSize( 430,200 ) );
 	steptype_colour_book->SetMaxSize( wxSize( 1200,1000 ) );
 
 	steptype_colour_character_panel = new wxPanel( steptype_colour_book, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -58,6 +58,7 @@ class GUI_Base : public wxFrame
 		wxMenu* menu_file;
 		wxMenu* menu_script;
 		wxMenu* menu_steptypes;
+		wxMenuItem* steptypecolour_changer;
 		wxMenu* menu_shortcuts;
 		wxMenu* menu_goals;
 		wxMenu* menu_loglevel;
@@ -191,6 +192,7 @@ class GUI_Base : public wxFrame
 		virtual void OnMenuExit( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnChooseLocation( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnGenerateScript( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnChangeSteptypeColoursMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnWalkMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCraftMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnTechMenuSelected( wxCommandEvent& event ) { event.Skip(); }
@@ -395,6 +397,40 @@ class BaseForDialogProgress : public wxDialog
 		BaseForDialogProgress( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Generating Script"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE );
 
 		~BaseForDialogProgress();
+
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/// Class StepTypeColoursDialog
+///////////////////////////////////////////////////////////////////////////////
+class StepTypeColoursDialog : public wxDialog
+{
+	private:
+
+	protected:
+		wxBoxSizer* StepTypeColoursDialog_sizer;
+		wxStaticText* steptype_colour_label;
+		wxListbook* steptype_colour_book;
+		wxPanel* steptype_colour_character_panel;
+		wxBoxSizer* stc_character_sizer;
+		wxFlexGridSizer* stc_character_grid_sizer;
+		wxPanel* steptype_colour_building_panel;
+		wxBoxSizer* stc_building_sizer;
+		wxFlexGridSizer* stc_building_grid_sizer;
+		wxPanel* steptype_colour_game_panel;
+		wxBoxSizer* stc_game_sizer;
+		wxFlexGridSizer* stc_game_grid_sizer;
+
+		// Virtual event handlers, override them in your derived class
+		virtual void OnCloseStepTypeColoursChanger( wxCloseEvent& event ) { event.Skip(); }
+		virtual void OnInitStepTypeColoursDialog( wxInitDialogEvent& event ) { event.Skip(); }
+
+
+	public:
+
+		StepTypeColoursDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Step type colours"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE|wxBORDER_RAISED|wxTAB_TRAVERSAL );
+
+		~StepTypeColoursDialog();
 
 };
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -32,6 +32,9 @@ namespace settings
         //entry string for json : shortcuts map
         const string shortcuts = "shortcuts";
 
+        //entry string for json : colours
+        const string colours = "colours";
+
         //filename for settings json
         const string filename = "generator-settings.json";
 
@@ -236,13 +239,15 @@ namespace settings
         {
             string last_tas;
             map<string, map<string, string>> shortcuts;
+            map<string, string> colours;
         };
 
         static void to_json(json& j, const setting& s)
         {
             j = json{
                 {"last_tas", s.last_tas},
-                {"shortcuts", s.shortcuts}
+                {"shortcuts", s.shortcuts},
+                {"colours", s.colours}
             };
         }
 
@@ -260,6 +265,16 @@ namespace settings
                 }
             else
                 s.shortcuts = {};
+
+            if (j.contains(file::colours))
+            {
+                for (auto& [key, value] : j.at(file::colours).items())
+                {
+                    s.colours.insert({key, value});
+                }
+            }
+            else
+                s.colours = {};
         }
     }
 

--- a/src/ShortcutChanger.cpp
+++ b/src/ShortcutChanger.cpp
@@ -68,7 +68,9 @@ void ShortcutChanger::DefaultShortcuts()
 
 void ShortcutChanger::OnCloseShortcutChanger(wxCloseEvent& event)
 {
-	settings::SaveSettingFile(&state);
+	settings::setting setting = settings::ReadSettingFile();
+	setting.shortcuts = state.shortcuts;
+	settings::SaveSettingFile(&setting);
 
 	event.Skip();
 }

--- a/src/SteptypeColour.cpp
+++ b/src/SteptypeColour.cpp
@@ -1,0 +1,162 @@
+#include <wx/clrpicker.h>
+#include "SteptypeColour.h"
+#include "StepNameToEnum.h"
+#include "Settings.h"
+
+using json = nlohmann::json;
+
+SteptypeColourHandler::SteptypeColourHandler(wxWindow* parent, wxGrid* steps, wxGrid* templates, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) :
+	StepTypeColoursDialog(parent, id, title, pos, size, style)
+{
+	this->grids = {steps, templates};
+
+	SteptypeToColour.resize(StepNames.size() + 1);
+	DefaultColours();
+	for (auto& [stepname, colour] : state.colours)
+	{
+		SteptypeToColour[ToStepType(stepname)] = sColour(colour);
+	}
+}
+
+SteptypeColourHandler::~SteptypeColourHandler()
+{
+	for (auto& [name, picker] : mapCtrl)
+	{
+		picker->Disconnect(wxEVT_COMMAND_COLOURPICKER_CHANGED, wxColourPickerEventHandler(SteptypeColourHandler::OnSteptypeColoursPickerColourChanged), NULL, this);
+	}
+}
+
+void SteptypeColourHandler::OnSteptypeColoursPickerColourChanged(wxColourPickerEvent& event)
+{
+	StepType type = e_stop;
+	wxColour colour = wxColour("Black");
+
+	for (auto& [stepname, picker] : mapCtrl)
+	{
+		if (picker == event.GetEventObject())
+		{
+			colour = picker->GetColour();
+			type = ToStepType(stepname);
+			SteptypeToColour[type] = sColour(colour);
+
+			state.colours.insert_or_assign(stepname, colour.GetAsString());
+			break;
+		}
+	}
+	
+	wxString stepname = wxString(StepNames[type]);
+	for (auto grid : grids)
+	{
+		const int size = grid->GetNumberRows();
+		for (int i = 0; i < size; i++)
+		{
+			auto value = grid->GetCellValue(i, 0);
+			if (value == stepname)
+			{
+				grid->SetCellBackgroundColour(i, 0, colour);
+			}
+		}
+	}
+	
+}
+
+void SteptypeColourHandler::Build()
+{
+	DefaultColours();
+	settings::setting s = settings::ReadSettingFile();
+
+	for (auto& [stepname, colour] : state.colours)
+	{
+		if (s.colours.contains(stepname))
+		{
+			state.colours[stepname] = s.colours[stepname];
+		}
+	}
+
+	enum gridtypes
+	{
+		unknown, Character, Building, Game
+	};
+
+	vector<std::tuple<wxGridSizer*, string, wxPanel*, wxSizer*, gridtypes> > grids = {
+		{stc_character_grid_sizer, "Character", steptype_colour_character_panel, stc_character_sizer, Character},
+		{stc_building_grid_sizer, "Building", steptype_colour_building_panel, stc_building_sizer, Building},
+		{stc_game_grid_sizer, "Game", steptype_colour_game_panel, stc_game_sizer, Game}
+	};
+
+	vector<gridtypes> steptypeToGridtype{unknown};
+	{
+		steptypeToGridtype.resize(StepNames.size() + 1);
+		steptypeToGridtype[e_stop] = Game;
+		steptypeToGridtype[e_build] = Building;
+		steptypeToGridtype[e_craft] = Character;
+		steptypeToGridtype[e_game_speed] = Game;
+		steptypeToGridtype[e_pause] = Game;
+		steptypeToGridtype[e_save] = Game;
+		steptypeToGridtype[e_recipe] = Building;
+		steptypeToGridtype[e_limit] = Building;
+		steptypeToGridtype[e_filter] = Building;
+		steptypeToGridtype[e_rotate] = Building;
+		steptypeToGridtype[e_priority] = Building;
+		steptypeToGridtype[e_put] = Building;
+		steptypeToGridtype[e_take] = Building;
+		steptypeToGridtype[e_mine] = Character;
+		steptypeToGridtype[e_launch] = Building;
+		steptypeToGridtype[e_walk] = Character;
+		steptypeToGridtype[e_tech] = Character;
+		steptypeToGridtype[e_drop] = Character;
+		steptypeToGridtype[e_pick_up] = Character;
+		steptypeToGridtype[e_idle] = Character;
+		steptypeToGridtype[e_cancel_crafting] = Character;
+		steptypeToGridtype[e_never_idle] = Game;
+		steptypeToGridtype[e_keep_walking] = Game;
+		steptypeToGridtype[e_keep_on_path] = Game;
+		steptypeToGridtype[e_keep_crafting] = Game;
+		steptypeToGridtype[e_shoot] = Character;
+		steptypeToGridtype[e_throw] = Character;
+	}
+
+	for (auto& [grid, menu, panel, outer_sizer, gridtype] : grids)
+	{
+		for (auto& [stepname, colour] : state.colours)
+		{
+			if (steptypeToGridtype[ToStepType(stepname)] != gridtype) continue; //paging
+
+			wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
+			wxStaticText* label = new wxStaticText(panel, wxID_ANY, wxString(stepname), wxDefaultPosition, wxSize(110, -1), wxALIGN_RIGHT);
+			label->Wrap(105);
+			sizer->Add(label, 0, wxALL, 5);
+			wxColourPickerCtrl* input = new wxColourPickerCtrl(panel, wxID_ANY, wxColour(std::string(colour)), wxDefaultPosition, wxSize(90, -1), wxCLRP_DEFAULT_STYLE | wxCLRP_SHOW_LABEL);
+			input->Connect(wxEVT_COMMAND_COLOURPICKER_CHANGED, wxColourPickerEventHandler(SteptypeColourHandler::OnSteptypeColoursPickerColourChanged), NULL, this);
+			mapCtrl.insert({stepname, input});
+			sizer->Add(input, 0, wxALL, 5);
+			grid->Add(sizer);
+		};
+		panel->SetSizerAndFit(outer_sizer);
+	}
+
+	this->SetSizerAndFit(StepTypeColoursDialog_sizer);
+}
+
+void SteptypeColourHandler::DefaultColours()
+{
+	state.colours = {};
+	for (int i = 1; i < StepNames.size(); i++)
+	{
+		state.colours[StepNames[i]] = DefaultColour(StepType(i)).GetAsString();
+	}
+}
+
+void SteptypeColourHandler::OnCloseStepTypeColoursChanger(wxCloseEvent& event)
+{
+	settings::setting setting = settings::ReadSettingFile();
+	setting.colours = state.colours;
+	settings::SaveSettingFile(&setting);
+
+	event.Skip();
+}
+
+void SteptypeColourHandler::OnInitStepTypeColoursDialog(wxInitDialogEvent& event)
+{
+	event.Skip();
+}

--- a/src/SteptypeColour.cpp
+++ b/src/SteptypeColour.cpp
@@ -123,10 +123,10 @@ void SteptypeColourHandler::Build()
 			if (steptypeToGridtype[ToStepType(stepname)] != gridtype) continue; //paging
 
 			wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
-			wxStaticText* label = new wxStaticText(panel, wxID_ANY, wxString(stepname), wxDefaultPosition, wxSize(110, -1), wxALIGN_RIGHT);
-			label->Wrap(105);
+			wxStaticText* label = new wxStaticText(panel, wxID_ANY, wxString(stepname), wxDefaultPosition, wxSize(80, -1), wxALIGN_RIGHT);
+			label->Wrap(75);
 			sizer->Add(label, 0, wxALL, 5);
-			wxColourPickerCtrl* input = new wxColourPickerCtrl(panel, wxID_ANY, wxColour(std::string(colour)), wxDefaultPosition, wxSize(90, -1), wxCLRP_DEFAULT_STYLE | wxCLRP_SHOW_LABEL);
+			wxColourPickerCtrl* input = new wxColourPickerCtrl(panel, wxID_ANY, wxColour(std::string(colour)), wxDefaultPosition, wxSize(70, -1), wxCLRP_DEFAULT_STYLE | wxCLRP_SHOW_LABEL);
 			input->Connect(wxEVT_COMMAND_COLOURPICKER_CHANGED, wxColourPickerEventHandler(SteptypeColourHandler::OnSteptypeColoursPickerColourChanged), NULL, this);
 			mapCtrl.insert({stepname, input});
 			sizer->Add(input, 0, wxALL, 5);

--- a/src/SteptypeColour.h
+++ b/src/SteptypeColour.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <map>
+#include <iostream>
+#include <fstream>
+#include <filesystem>
+
+#include "GUI_Base.h"
+#include "Settings.h"
+
+class SteptypeColourHandler : public StepTypeColoursDialog
+{
+private:
+	struct sColour
+	{
+		bool set = false;
+		wxColour colour;
+		sColour()
+		{
+			set = false;
+			colour = {};
+		}
+		sColour(wxColour c)
+		{
+			colour = c;
+			set = true;
+		}
+		sColour(std::string s)
+		{
+			colour = wxColour(s);
+			set = true;
+		}
+	};
+
+public:
+	SteptypeColourHandler(wxWindow* parent, wxGrid* steps, wxGrid* templates, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style);
+
+	~SteptypeColourHandler();
+
+	void OnSteptypeColoursPickerColourChanged(wxColourPickerEvent& event);
+
+	void Build();
+	void DefaultColours();
+
+	static inline void UpdateSteptypeColoursFromFile()
+	{
+		try
+		{
+			SteptypeToColour.resize(StepNames.size() + 1);
+			settings::setting s = settings::ReadSettingFile();
+			// For each shortcut type in the settings file
+			for (auto& [steptype, colour] : s.colours)
+			{
+				SteptypeToColour[ToStepType(steptype)] = sColour(colour);
+			}
+		}
+		catch (...) { } // ignore all errors
+	}
+
+	static inline wxColour GetStepColourOrDefault(StepType steptype)
+	{
+		return SteptypeToColour[steptype].set ? SteptypeToColour[steptype].colour : DefaultColour(steptype);
+	}
+
+	static inline wxColour DefaultColour(StepType steptype)
+	{
+		switch (steptype)
+		{
+			case e_build:
+				return wxColour("Cyan");
+			case e_stop:
+				return wxColour("Red");
+			case e_craft:
+				return wxColour("Light Grey");
+			case e_game_speed:
+			case e_pause:
+			case e_save:
+			case e_keep_crafting:
+			case e_keep_on_path:
+			case e_keep_walking:
+			case e_never_idle:
+				return wxColour("Yellow");
+			default:
+				return wxColour("White");
+		}
+	}
+
+	static inline vector<sColour> SteptypeToColour;
+
+protected:
+	std::map<std::string, wxColourPickerCtrl*> mapCtrl = {};
+	settings::setting state;
+	vector<wxGrid*> grids;
+
+	void OnCloseStepTypeColoursChanger(wxCloseEvent& event);
+	void OnInitStepTypeColoursDialog(wxInitDialogEvent& event);
+};

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -2,6 +2,7 @@
 
 #include "cMain.h"
 #include "ShortcutChanger.h"
+#include "SteptypeColour.h"
 
 cMain::cMain() : GUI_Base(nullptr, wxID_ANY, window_title, wxPoint(30, 30), wxSize(1840, 950))
 {
@@ -136,6 +137,7 @@ cMain::cMain() : GUI_Base(nullptr, wxID_ANY, window_title, wxPoint(30, 30), wxSi
 
 	//set shortcuts from settings file
 	ShortcutChanger::UpdateShortcutsFromFile(main_menubar);
+	SteptypeColourHandler::UpdateSteptypeColoursFromFile();
 	settings::setting settings = settings::ReadSettingFile();
 	if (settings.last_tas != "")
 	{
@@ -479,31 +481,9 @@ bool cMain::ChangeRow(wxGrid* grid, StepParameters step)
 	return true;
 }
 
-void cMain::BackgroundColorUpdate(wxGrid* grid, int row, StepType Step)
+void cMain::BackgroundColorUpdate(wxGrid* grid, int row, StepType step)
 {
-	switch (Step)
-	{
-		case e_stop:
-			grid->SetCellBackgroundColour(row, 0, *wxRED);
-			return;
-		case e_build:
-			grid->SetCellBackgroundColour(row, 0, *wxCYAN);
-			return;
-		case e_craft:
-			grid->SetCellBackgroundColour(row, 0, *wxLIGHT_GREY);
-			return;
-		case e_game_speed:
-		case e_pause:
-		case e_save:
-		case e_keep_crafting:
-		case e_keep_on_path:
-		case e_keep_walking:
-		case e_never_idle:
-			grid->SetCellBackgroundColour(row, 0, *wxYELLOW);
-			return;
-		default:
-			grid->SetCellBackgroundColour(row, 0, *wxWHITE);
-	}
+	grid->SetCellBackgroundColour(row, 0, SteptypeColourHandler::GetStepColourOrDefault(step));
 }
 
 void cMain::UpdateTemplateGrid(wxGrid* grid, vector<StepParameters>& steps)
@@ -1673,10 +1653,6 @@ void cMain::OnGenerateScript(wxCommandEvent& event)
 
 void cMain::OnChangeShortcutMenuSelected(wxCommandEvent& event)
 {
-	// open state file
-	// create changer
-	// send file & menu items to changer
-
 	ShortcutChanger * sc = new ShortcutChanger(this, 
 		wxID_ANY,
 		wxT("Change shortcuts"), 
@@ -1685,6 +1661,24 @@ void cMain::OnChangeShortcutMenuSelected(wxCommandEvent& event)
 		wxCAPTION | wxCLOSE_BOX | wxDEFAULT_DIALOG_STYLE | wxSTAY_ON_TOP | wxBORDER_DEFAULT);
 
 	sc->Build(main_menubar);	
+
+	sc->Show();
+
+	event.Skip();
+}
+
+void cMain::OnChangeSteptypeColoursMenuSelected(wxCommandEvent& event)
+{
+	SteptypeColourHandler* sc = new SteptypeColourHandler(this,
+		grid_steps, 
+		grid_template,
+		wxID_ANY,
+		wxT("Change colours"),
+		wxDefaultPosition,
+		wxDefaultSize,
+		wxCAPTION | wxCLOSE_BOX | wxDEFAULT_DIALOG_STYLE | wxSTAY_ON_TOP | wxBORDER_DEFAULT);
+
+	sc->Build();
 
 	sc->Show();
 

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -65,6 +65,8 @@ protected:
 	void OnGenerateScript(wxCommandEvent& event);
 
 	// Step types menu
+	void OnChangeSteptypeColoursMenuSelected(wxCommandEvent& event);
+
 	void OnWalkMenuSelected(wxCommandEvent& event);
 	void OnCraftMenuSelected(wxCommandEvent& event);
 	void OnTechMenuSelected(wxCommandEvent& event);


### PR DESCRIPTION
- Added steptype colour to handle painting steps grid and imporing colour settings.
- Added colour settings to generator settings.
- Added GUI dialog to change steptype colours.

### Added a GUI window to handle colours
![image](https://github.com/MortenTobiasNielsen/Factorio-TAS-Generator/assets/18309265/b787246e-fcd5-4d24-8aab-6a4998e2ea35)
![image](https://github.com/MortenTobiasNielsen/Factorio-TAS-Generator/assets/18309265/a9f0fd59-4505-46b6-9769-6b463a9339f4)
![image](https://github.com/MortenTobiasNielsen/Factorio-TAS-Generator/assets/18309265/6fc5dc70-6b96-4b8f-b349-a94d40be5b3d)
![image](https://github.com/MortenTobiasNielsen/Factorio-TAS-Generator/assets/18309265/6c98b4e2-a04e-4be4-9311-e9f6281e4611)

### Based on Shortcut changer
This is largely based on the shortcut changer. With a few minor differences and some major upgrades.

1. I have elected to split the step types according to their type type (type^2) so they align with the Top GUI. However this split is GUI only, so the code deals with it in a custom way.
2. The step and template grids are updated immediately. It doesn't appear like it cost a lot of performance.
3. Similar to the shortcut changer, the generator settings file is only updated when the dialog is dismissed.

### Other
As per usual the generator file is forwards upgradable but not backwards.

I meant to include the colors of diagonal & straight walk, as well as intermediate walk. But this PR was already huge 😎

Also do you prefer color or colour? It seems like github, factorio and my browser prefers color. While wxWidget prefers colour.