### PR TITLE
Improved performance of open tas

### DIFF
--- a/src/Functions.cpp
+++ b/src/Functions.cpp
@@ -51,27 +51,19 @@ void find_coordinates(std::string& x_cord, std::string& y_cord, std::string& dir
 	}
 }
 
-string Capitalize(const wxString& stringToCapitalize, const bool isItem)
+string inline Capitalize_std(const std::string& stringToCapitalize, const bool isItem)
 {
-	if (stringToCapitalize == "")
-	{
-		return stringToCapitalize.ToStdString();
-	}
+	if (stringToCapitalize.empty()) return stringToCapitalize;
+	std::string capitalizedString = stringToCapitalize;
+	const int stringLength = capitalizedString.length();
 
-	string capitalizedString = stringToCapitalize.ToStdString();
 	capitalizedString[0] = std::toupper(stringToCapitalize[0]);
-	for (int i = 1; i < capitalizedString.length(); ++i)
+	for (int i = 1; i < stringLength; ++i)
 	{
 		capitalizedString[i] = tolower(stringToCapitalize[i]);
 	}
 
-	if (!isItem)
-	{
-		return capitalizedString;
-	}
-
-	int stringLength = capitalizedString.length();
-	if (stringLength > 3 &&  capitalizedString.substr(stringLength - 3, 3) == "mk2")
+	if (isItem && stringLength > 3 && capitalizedString.substr(stringLength - 3, 3) == "mk2")
 	{
 		capitalizedString[stringLength - 3] = 'M';
 		capitalizedString[stringLength - 2] = 'K';
@@ -79,6 +71,16 @@ string Capitalize(const wxString& stringToCapitalize, const bool isItem)
 	}
 
 	return capitalizedString;
+}
+
+string inline Capitalize(const wxString& stringToCapitalize, const bool isItem)
+{
+	if (stringToCapitalize == "")
+	{
+		return "";
+	}
+
+	return Capitalize_std(stringToCapitalize.ToStdString(), isItem);
 }
 
 bool equals_ignore_case(const std::string_view& lhs, const std::string_view& rhs)

--- a/src/Functions.cpp
+++ b/src/Functions.cpp
@@ -51,7 +51,7 @@ void find_coordinates(std::string& x_cord, std::string& y_cord, std::string& dir
 	}
 }
 
-string inline Capitalize_std(const std::string& stringToCapitalize, const bool isItem)
+string Capitalize(const std::string& stringToCapitalize, const bool isItem)
 {
 	if (stringToCapitalize.empty()) return stringToCapitalize;
 	std::string capitalizedString = stringToCapitalize;
@@ -73,14 +73,14 @@ string inline Capitalize_std(const std::string& stringToCapitalize, const bool i
 	return capitalizedString;
 }
 
-string inline Capitalize(const wxString& stringToCapitalize, const bool isItem)
+string Capitalize(const wxString& stringToCapitalize, const bool isItem)
 {
 	if (stringToCapitalize == "")
 	{
 		return "";
 	}
 
-	return Capitalize_std(stringToCapitalize.ToStdString(), isItem);
+	return Capitalize(stringToCapitalize.ToStdString(), isItem);
 }
 
 bool equals_ignore_case(const std::string_view& lhs, const std::string_view& rhs)

--- a/src/Functions.h
+++ b/src/Functions.h
@@ -20,8 +20,8 @@ using std::stringstream;
 
 bool check_input(const string& item, const vector<string>& all_items);
 
-string inline Capitalize_std(const std::string& stringToCapitalize, const bool isItem = false);
-string inline Capitalize(const wxString& stringToCapitalize, const bool isItem = false);
+string Capitalize(const std::string& stringToCapitalize, const bool isItem = false);
+string Capitalize(const wxString& stringToCapitalize, const bool isItem = false);
 
 bool equals_ignore_case(const std::string_view& lhs, const std::string_view& rhs);
 bool starts_with_ignore_case(const std::string& base, const std::string& start);

--- a/src/Functions.h
+++ b/src/Functions.h
@@ -20,7 +20,8 @@ using std::stringstream;
 
 bool check_input(const string& item, const vector<string>& all_items);
 
-string Capitalize(const wxString& stringToCapitalize, const bool isItem = false);
+string inline Capitalize_std(const std::string& stringToCapitalize, const bool isItem = false);
+string inline Capitalize(const wxString& stringToCapitalize, const bool isItem = false);
 
 bool equals_ignore_case(const std::string_view& lhs, const std::string_view& rhs);
 bool starts_with_ignore_case(const std::string& base, const std::string& start);

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -138,11 +138,11 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 			segment_size != step_segment_size_without_comment_and_colour &&
 			segment_size != step_segment_size_without_comment_and_colour_and_modifiers)
 		{
-			if (segments[0] == save_templates_indicator)
+			if (segment_size >= 0 && segments[0] == save_templates_indicator)
 			{
 				return Template;
 			}
-			else if (segment_size == 1 && (segments[0] == save_groups_indicator))
+			else if (segment_size >= 0 && segments[0] == save_groups_indicator)
 			{
 				return Group;
 			}
@@ -151,7 +151,7 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 				return Invalid;
 			}
 		}
-			
+
 		StepParameters step(invalidX, 0);
 
 		if (segments[1] != "")

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -162,11 +162,11 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 			step.OriginalY = step.Y;
 		}
 
-		step.Step = Capitalize_std(segments[0]);
-		step.Amount = Capitalize_std(segments[3]);
-		step.Item = Capitalize_std(segments[4], true);
-		step.Orientation = Capitalize_std(segments[5]);
-		step.Direction = Capitalize_std(segments[6]);
+		step.Step = Capitalize(segments[0]);
+		step.Amount = Capitalize(segments[3]);
+		step.Item = Capitalize(segments[4], true);
+		step.Orientation = Capitalize(segments[5]);
+		step.Direction = Capitalize(segments[6]);
 		step.Size = segments[7] != "" ? stoi(segments[7]) : 1;
 		step.Buildings = segments[8] != "" ? stoi(segments[8]) : 1;
 		step.Comment = segment_size == step_segment_size || segment_size == step_segment_size_without_colour ? segments[9] : "";

--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -132,67 +132,47 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 
 	while (update_segment(file))
 	{
-		if (segments.size() != step_segment_size && 
-			segments.size() != step_segment_size_without_colour &&
-			segments.size() != step_segment_size_without_comment_and_colour &&
-			segments.size() != step_segment_size_without_comment_and_colour_and_modifiers)
+		const size_t segment_size = segments.size();
+		if (segment_size != step_segment_size &&
+			segment_size != step_segment_size_without_colour &&
+			segment_size != step_segment_size_without_comment_and_colour &&
+			segment_size != step_segment_size_without_comment_and_colour_and_modifiers)
 		{
 			if (segments[0] == save_templates_indicator)
 			{
 				return Template;
 			}
-
-			if (segments.size() == 1 && (segments[0] == save_groups_indicator))
+			else if (segment_size == 1 && (segments[0] == save_groups_indicator))
 			{
 				return Group;
 			}
-
-			return Invalid;
+			else
+			{
+				return Invalid;
+			}
 		}
-
-		string comment = "";
-		if (segments.size() == step_segment_size || segments.size() == step_segment_size_without_colour)
-		{
-			comment = segments[9];
-		}
-
+			
 		StepParameters step(invalidX, 0);
 
 		if (segments[1] != "")
 		{
 			step.X = stod(segments[1]);
-			step.OriginalX = stod(segments[1]);
+			step.OriginalX = step.X;
 			step.Y = stod(segments[2]);
-			step.OriginalY = stod(segments[2]);
+			step.OriginalY = step.Y;
 		}
 
-		if (segments[7] != "")
-		{
-			step.Size = stoi(segments[7]);
-		}
-
-		if (segments[8] != "")
-		{
-			step.Buildings = stoi(segments[8]);
-		}
-
-		step.Step = Capitalize(segments[0]);
-		step.Amount = Capitalize(segments[3]);
-		step.Item = Capitalize(segments[4], true);
-		step.Orientation = Capitalize(segments[5]);
-		step.Direction = Capitalize(segments[6]);
-		step.Modifiers = segments.size() == step_segment_size ? segments[11] : "";
-		step.Comment = comment;
-
-		if (segments.size() == step_segment_size)
-		{
-			step.Colour = segments[10];
-		}
-		else
-		{
-			step.Colour = "";
-		}
-
+		step.Step = Capitalize_std(segments[0]);
+		step.Amount = Capitalize_std(segments[3]);
+		step.Item = Capitalize_std(segments[4], true);
+		step.Orientation = Capitalize_std(segments[5]);
+		step.Direction = Capitalize_std(segments[6]);
+		step.Size = segments[7] != "" ? stoi(segments[7]) : 1;
+		step.Buildings = segments[8] != "" ? stoi(segments[8]) : 1;
+		step.Comment = segment_size == step_segment_size || segment_size == step_segment_size_without_colour ? segments[9] : "";
+		step.Colour = segment_size == step_segment_size ? segments[10] : "";
+		step.Modifiers = segment_size == step_segment_size ? segments[11] : "";
+		
 		if (step.Step == "Start")
 		{
 			continue; // Ignore start steps, given that they are obsolete.
@@ -272,7 +252,7 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 
 		lines_processed++;
 
-		if (lines_processed > 0 && lines_processed % 25 == 0)
+		if (lines_processed > 0 && lines_processed % 250 == 0)
 		{
 			dialog_progress_bar->set_progress(static_cast<float>(lines_processed) / static_cast<float>(total_lines) * 100.0f - 50);
 			wxYield();
@@ -685,7 +665,8 @@ bool OpenTas::update_segment(std::ifstream& file)
 	{
 		data_line.str(line);
 
-		segments = {};
+		segments.clear();
+		segments.reserve(16);
 
 		while (std::getline(data_line, segment, ';'))
 		{

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1666,7 +1666,7 @@ void cMain::PopulateStepGrid()
 	}
 
 	size_t steps = StepGridData.size();
-
+	grid_steps->BeginBatch();
 	grid_steps->InsertRows(0, steps);
 
 	for (int i = 0; i < steps; i++)
@@ -1685,6 +1685,7 @@ void cMain::PopulateStepGrid()
 			grid_steps->SetCellBackgroundColour(i, 3, colour);
 		}
 	}
+	grid_steps->EndBatch();
 }
 
 void cMain::OnMenuSave(wxCommandEvent& event)


### PR DESCRIPTION
- Simplified open tas, extract steps.
- Improved performance loading steps in grid_steps by using batch.
- Improved performance of open tas by adding new Capitalize (std) function that doesn't convert back and forth between std and wx string.

### Test
I did some test on open TAS with 204k rows. In my test it took 37-39 seconds to load all those rows. The 2 steps that contributed the most was PopulateStepGrid (17s) and OpenTas::extract_steps (19s)

Using beginBatch & endBatch reduced PopulateStepGrid from ~17 seconds to ~10 seconds. So reducing that by 40%.

Changing the Capitalize function, so it didn't implicitly convert segments strings from std::string to wxString before converting them back std::string. Improved the extract_steps step from ~19s to ~10s.

### Bias
My test was using 100 copies of my new steel axe run, which obviously isn't a real example of a run. It is majorly skewed towards take and put tasks.