### PR TITLE
Refactor Orientation

### DIFF
--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -315,7 +315,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 
 			case e_drop:
 				building = "Item on ground";
-				build_orientation = build_orientations[1];
+				build_orientation = orientation_list[0];
 
 				drop(currentStep, "1", x_cord, y_cord, item, building, comment);
 				break;
@@ -435,7 +435,7 @@ void GenerateScript::SetBuildingAndOrientation(StepParameters* step)
 	}
 
 	building = FindBuildingName(step->BuildingIndex);
-	build_orientation = build_orientations[step->OrientationEnum];
+	build_orientation = orientation_list[step->OrientationEnum];
 }
 
 void GenerateScript::TransferParameters(StepParameters& stepParameters)
@@ -1088,26 +1088,7 @@ void GenerateScript::build(string step, string action, string x_cord, string y_c
 
 	item = check_item_name(item);
 
-	if (OrientationEnum == "North")
-	{
-		OrientationEnum = build_direction_struct.north;
-	}
-	else if (OrientationEnum == "South")
-	{
-		OrientationEnum = build_direction_struct.south;
-	}
-	else if (OrientationEnum == "East")
-	{
-		OrientationEnum = build_direction_struct.east;
-	}
-	else if (OrientationEnum == "West")
-	{
-		OrientationEnum = build_direction_struct.west;
-	}
-	else
-	{
-		return;
-	}
+	OrientationEnum = orientation_defines_list[MapStringToOrientation[OrientationEnum]];
 
 	step_list += Step(step, action, "\"build\", {" + x_cord + ", " + y_cord + "}, \"" + item + "\", " + OrientationEnum, comment);
 	total_steps += 1;

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -104,7 +104,7 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 		{
 			[[likely]] case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
-				step.OrientationEnum = OrientationToEnum[step.Orientation];
+				step.OrientationEnum = MapStringToOrientation[step.Orientation];
 
 				buildingsInSnapShot = ProcessBuildStep(buildingSnapshot, buildingsInSnapShot, step);
 				break;

--- a/src/Structures/Orientation.h
+++ b/src/Structures/Orientation.h
@@ -4,15 +4,36 @@
 #include <map>
 #include <string>
 
+/*
+Orientation and Direction is the same type, but different fields.
+	Orientation is used for the direction a building is facing
+	Direction is used for multibuild
+
+Factorio uses a longer list of directions: https://lua-api.factorio.com/latest/defines.html#defines.direction
+Factorio also uses a float between 0 and 1 to indicate direction.
+
+Buildings and vehicles can't be placed in half directions, with the exception of rails.
+The half directions are otherwise exclusive to characters and biters (which is why they aren't implemented)
+Underground belts are special as they use both belt_direction and building orientation (not implemented).
+*/
+
 static const struct
 {
-	std::string north = "defines.direction.north";
-	std::string south = "defines.direction.south";
+	std::string north = "defines.direction.north";	
 	std::string east = "defines.direction.east";
+	std::string south = "defines.direction.south";
 	std::string west = "defines.direction.west";
-} build_direction_struct;
+} orientation_defines;
 
-static const std::vector<std::string> build_orientations =
+static const std::vector<std::string> orientation_defines_list
+{
+	orientation_defines.north,
+	orientation_defines.east,
+	orientation_defines.south,
+	orientation_defines.west,
+};
+
+static const std::vector<std::string> orientation_list
 {
 	"North",
 	"East",
@@ -28,10 +49,10 @@ enum Orientation
 	West,
 };
 
-static inline std::map<std::string, Orientation> OrientationToEnum =
+static inline std::map<std::string, Orientation> MapStringToOrientation
 {
-	{build_orientations[North], North},
-	{build_orientations[East], East},
-	{build_orientations[South], South},
-	{build_orientations[West], West}
+	{orientation_list[North], North},
+	{orientation_list[East], East},
+	{orientation_list[South], South},
+	{orientation_list[West], West}
 };

--- a/src/Structures/StepParameters.cpp
+++ b/src/Structures/StepParameters.cpp
@@ -22,25 +22,25 @@ void StepParameters::Reset()
 
 void StepParameters::Next()
 {
-	if (Direction == build_orientations[North])
+	if (Direction == orientation_list[North])
 	{
 		Y -= Size;
 		return;
 	}
 
-	if (Direction == build_orientations[South])
+	if (Direction == orientation_list[South])
 	{
 		Y += Size;
 		return;
 	}
 
-	if (Direction == build_orientations[East])
+	if (Direction == orientation_list[East])
 	{
 		X += Size;
 		return;
 	}
 
-	if (Direction == build_orientations[West])
+	if (Direction == orientation_list[West])
 	{
 		X -= Size;
 		return;
@@ -145,7 +145,7 @@ bool StepParameters::operator==(const StepParameters& toCompare)
 
 	if (toCompare.X == X)
 	{
-		if (toCompare.Direction == build_orientations[South])
+		if (toCompare.Direction == orientation_list[South])
 		{
 			if (toCompare.Y > Y)
 			{
@@ -161,7 +161,7 @@ bool StepParameters::operator==(const StepParameters& toCompare)
 			}
 		}
 
-		if (toCompare.Direction == build_orientations[North])
+		if (toCompare.Direction == orientation_list[North])
 		{
 			if (toCompare.Y < Y)
 			{
@@ -180,7 +180,7 @@ bool StepParameters::operator==(const StepParameters& toCompare)
 
 	if (toCompare.Y == Y)
 	{
-		if (toCompare.Direction == build_orientations[East])
+		if (toCompare.Direction == orientation_list[East])
 		{
 			if (toCompare.X > X)
 			{
@@ -196,7 +196,7 @@ bool StepParameters::operator==(const StepParameters& toCompare)
 			}
 		}
 
-		if (toCompare.Direction == build_orientations[West])
+		if (toCompare.Direction == orientation_list[West])
 		{
 			if (toCompare.X < X)
 			{

--- a/src/TAS save file/OpenTas.cpp
+++ b/src/TAS save file/OpenTas.cpp
@@ -190,7 +190,7 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
-				step.OrientationEnum = OrientationToEnum[step.Orientation];
+				step.OrientationEnum = MapStringToOrientation[step.Orientation];
 
 				buildingsInSnapShot = ProcessBuildStep(buildingSnapshot, buildingsInSnapShot, step);
 				break;
@@ -350,7 +350,7 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
-				step.OrientationEnum = OrientationToEnum[step.Orientation];
+				step.OrientationEnum = MapStringToOrientation[step.Orientation];
 				break;
 
 			case e_priority:
@@ -487,7 +487,7 @@ bool OpenTas::extract_templates(std::ifstream& file, DialogProgressBar* dialog_p
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
-				step.OrientationEnum = OrientationToEnum[step.Orientation];
+				step.OrientationEnum = MapStringToOrientation[step.Orientation];
 				break;
 
 			case e_priority:

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -69,7 +69,7 @@ cMain::cMain() : GUI_Base(nullptr, wxID_ANY, window_title, wxPoint(30, 30), wxSi
 		tech_choices.Add(s);
 	}
 
-	for (auto& s : build_orientations)
+	for (auto& s : orientation_list)
 	{
 		building_orientation_choices.Add(s);
 	}
@@ -90,14 +90,14 @@ cMain::cMain() : GUI_Base(nullptr, wxID_ANY, window_title, wxPoint(30, 30), wxSi
 
 	cmb_building_orientation->Clear();
 	cmb_direction_to_build->Clear();
-	for (auto it = build_orientations.begin(); it < build_orientations.end(); it++)
+	for (auto it = orientation_list.begin(); it < orientation_list.end(); it++)
 	{
 		cmb_building_orientation->Append(*it);
 		cmb_direction_to_build->Append(*it);
 	}
-	cmb_building_orientation->SetValue(*build_orientations.begin());
+	cmb_building_orientation->SetValue(*orientation_list.begin());
 	cmb_building_orientation->AutoComplete(building_orientation_choices);
-	cmb_direction_to_build->SetValue(*build_orientations.begin());
+	cmb_direction_to_build->SetValue(*orientation_list.begin());
 	cmb_direction_to_build->AutoComplete(building_orientation_choices);
 
 	cmb_item->Clear();
@@ -2489,13 +2489,13 @@ bool cMain::IsValidBuildStep(StepParameters& stepParameters)
 		return false;
 	}
 
-	if (!check_input(stepParameters.Orientation, build_orientations))
+	if (!check_input(stepParameters.Orientation, orientation_list))
 	{
 		wxMessageBox("The build direction is not valid - please try again", "Please use the build direction dropdown menu");
 		return false;
 	}
 
-	if (!check_input(stepParameters.Direction, build_orientations))
+	if (!check_input(stepParameters.Direction, orientation_list))
 	{
 		wxMessageBox("The direction to build is not valid - please try again", "Please use the direction to build dropdown menu");
 		return false;
@@ -2588,7 +2588,7 @@ bool cMain::IsValidPutTakeStep(StepParameters& stepParameters)
 		return false;
 	}
 
-	if (!check_input(stepParameters.Direction, build_orientations))
+	if (!check_input(stepParameters.Direction, orientation_list))
 	{
 		wxMessageBox("The direction to build is not valid - please try again", "Please use the direction to build dropdown menu");
 		return false;
@@ -2757,7 +2757,7 @@ bool cMain::ValidateAllSteps()
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType.find(step.Item)->second;
-				step.OrientationEnum = OrientationToEnum.find(step.Orientation)->second;
+				step.OrientationEnum = MapStringToOrientation.find(step.Orientation)->second;
 
 				buildingsInSnapShot = ProcessBuildStep(BuildingsSnapShot, buildingsInSnapShot, step);
 				break;


### PR DESCRIPTION
Renamed build_direction_struct to orientation_defines
Renamed build_orientations to orientation_list
Renamed OrientationToEnum to MapStringToOrientation Added orientation_defines_list
Simplified the GenerateScript::build match orientation to define Changed direction of "Item on ground" to north