### PR TITLE
Refactored StepParameters::Modifiers.

### DIFF
--- a/src/Factorio-TAS-Generator.vcxproj
+++ b/src/Factorio-TAS-Generator.vcxproj
@@ -99,6 +99,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(WXWIN)\include; $(WXWIN)\include\msvc</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -135,6 +136,7 @@
       <AdditionalIncludeDirectories>$(WXWIN)\include; $(WXWIN)\include\msvc</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -203,6 +205,7 @@
     <ClInclude Include="Structures\Orientation.h" />
     <ClInclude Include="Structures\ParameterChoices.h" />
     <ClInclude Include="Structures\Priority.h" />
+    <ClInclude Include="Structures\StepModifiers.h" />
     <ClInclude Include="Structures\StepParameters.h" />
     <ClInclude Include="Structures\StepType.h" />
     <ClInclude Include="TAS save file\OpenTas.h" />

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -450,13 +450,13 @@ void GenerateScript::TransferParameters(StepParameters& stepParameters)
 	amount_of_buildings = to_string(stepParameters.Buildings);
 	comment = stepParameters.Comment;
 	modifiers = {
-		.wait_for = stepParameters.Modifiers.find("wait for") != std::string::npos,
-		.cancel = stepParameters.Modifiers.find("cancel") != std::string::npos,
-		.no_order = stepParameters.Modifiers.find("no order") != std::string::npos,
-		.walk_towards = stepParameters.Modifiers.find("walk towards") != std::string::npos,
-		.skip = stepParameters.Modifiers.find("skip") != std::string::npos,
-		.force = stepParameters.Modifiers.find("force") != std::string::npos,
-		.split = stepParameters.Modifiers.find("split") != std::string::npos,
+		.no_order = stepParameters.Modifiers.no_order,
+		.skip = stepParameters.Modifiers.skip,
+		.wait_for = stepParameters.Modifiers.wait_for,
+		.force = stepParameters.Modifiers.force,
+		.cancel_others = stepParameters.Modifiers.cancel_others,
+		.split = stepParameters.Modifiers.split,
+		.walk_towards = stepParameters.Modifiers.walk_towards,
 	};
 }
 
@@ -754,23 +754,9 @@ string GenerateScript::Comment(string comment)
 	return comment == "" ? "" : ", comment = \"" + comment + "\"";
 }
 
-string GenerateScript::Modifiers()
-{
-	string str = ", ";
-	str += modifiers.cancel ? " cancel = true," : "";
-	str += modifiers.no_order ? " no_order = true," : "";
-	str += modifiers.wait_for ? " wait_for = true," : "";
-	str += modifiers.walk_towards ? " walk_towards = true," : "";
-	//str += modifiers.skip ? " skip = true," : "";
-	//str += modifiers.force ? " force = true," : "";
-	//str += modifiers.split ? " split = true," : "";
-
-	return str.size() < 3 ? "" : str;
-}
-
 string GenerateScript::Step(string step, string action, string details, string comment = "")
 {
-	return signature(step, action) + details + Comment(comment) + Modifiers() + "}\n";
+	return signature(step, action) + details + Comment(comment) + modifiers.ToLua() + "}\n";
 }
 
 void GenerateScript::walk(string step, string action, string x_cord, string y_cord, string comment)

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -61,16 +61,7 @@ private:
 	string priority_out;
 	string building;
 
-	struct
-	{
-		bool wait_for = false;
-		bool cancel = false;
-		bool no_order = false;
-		bool walk_towards = false;
-		bool skip = false;
-		bool force = false;
-		bool split = false;
-	} modifiers;
+	StepModifiers modifiers;
 
 	string last_walking_comment;
 
@@ -155,7 +146,6 @@ private:
 
 	string signature(string step, string action);
 	string Comment(string comment);
-	string Modifiers();
 	string Step(string step, string action, string details, string comment);
 	WarningsStatesCounters warning_state_counters;
 

--- a/src/Shared functions/Functions.cpp
+++ b/src/Shared functions/Functions.cpp
@@ -180,8 +180,8 @@ void ProcessMiningStep(vector<Building>& buildings, int buildingsInSnapShot, Ste
 	{
 		if (stepParameters == buildings[i])
 		{
-			if (stepParameters.Modifiers.find("split") != std::string::npos ||
-				stepParameters.Modifiers.find("skip") != std::string::npos ||
+			if (stepParameters.Modifiers.split ||
+				stepParameters.Modifiers.skip ||
 				Capitalize(stepParameters.Comment) == "Split")
 			{
 				return;

--- a/src/Structures/StepModifiers.h
+++ b/src/Structures/StepModifiers.h
@@ -1,0 +1,113 @@
+#pragma once
+#include <vector>
+#include <string>
+
+using std::vector;
+using std::string;
+
+struct StepModifiers
+{
+	// Fields
+	bool no_order = false,
+		skip = false,
+		wait_for = false,
+		force = false,
+		cancel_others = false,
+		split = false,
+		walk_towards = false;
+
+private:
+	static const struct
+	{
+		const string NO_ORDER = "no order",
+			SKIP = "skip",
+			WAIT_FOR = "wait for",
+			FORCE = "force",
+			CANCEL_OTHERS = "cancel others",
+			SPLIT = "split",
+			WALK_TOWARDS = "walk towards";
+	} inline StepModifiersLookupString;
+
+	static inline const vector<const string*> StepModifiersLookupStrings = {
+		& StepModifiersLookupString.NO_ORDER,
+		& StepModifiersLookupString.SKIP,
+		& StepModifiersLookupString.WAIT_FOR,
+		& StepModifiersLookupString.FORCE,
+		& StepModifiersLookupString.CANCEL_OTHERS,
+		& StepModifiersLookupString.SPLIT,
+		& StepModifiersLookupString.WALK_TOWARDS,
+	};
+
+	inline const vector<bool> ToVector()
+	{
+		return {
+			no_order,
+			skip,
+			wait_for,
+			force,
+			cancel_others,
+			split,
+			walk_towards,
+		};
+	}
+
+	inline const vector<bool*> ToPointerVector()
+	{
+		return {
+			&no_order,
+			&skip,
+			&wait_for,
+			&force,
+			&cancel_others,
+			&split,
+			&walk_towards,
+		};
+	}
+
+public:
+	/// <summary>Sets the values using a string as input</summary>
+	/// <param name="str">Input string containing any number of LookupStrings</param>
+	inline void FromString(string str)
+	{
+		if (str.empty()) 
+		{ // fast => set everything to false
+			no_order = skip = wait_for = force = cancel_others = split = walk_towards = false;
+		}
+		
+		auto data = ToPointerVector();
+		for (int i = 0; i < StepModifiersLookupStrings.size(); i++)
+			*data[i] = str.find(*StepModifiersLookupStrings[i]) != std::string::npos;
+		
+	}
+
+	/// <summary>Converts the modifiers to a string in the format => "" | "<modifier>" | "<modifier>, (recursion)"</summary>
+	inline const string ToString()
+	{
+		auto data = ToVector();
+		string output = ""; output.reserve(15*7); // Guessed max length 15 * 7 modifiers
+
+		for (int i = 0; i < StepModifiersLookupStrings.size(); i++)
+			if (data[i])
+				output +=  *StepModifiersLookupStrings[i] + ", ";
+
+		return output.ends_with(' ') ?
+			output.substr(0, output.size() - 2) : // remove last ", "
+			output;
+	}
+
+	inline const string ToLua()
+	{
+		string output = ", "; output.reserve(21 * 4 + 2); // Guessed max length 21 times 4 modifiers
+
+		output += cancel_others ? " cancel = true," : "";
+		output += no_order ? " no_order = true," : "";
+		output += wait_for ? " wait_for = true," : "";
+		output += walk_towards ? " walk_towards = true," : "";
+		/* Rest are not included since they are not relevant in lua
+		//output += skip ? " skip = true," : "";
+		//output += force ? " force = true," : "";
+		//output += split ? " split = true," : "";
+		*/
+		return output.size() < 3 ? "" : output;
+	}
+};

--- a/src/Structures/StepParameters.cpp
+++ b/src/Structures/StepParameters.cpp
@@ -49,6 +49,7 @@ void StepParameters::Next()
 
 string StepParameters::ToString()
 {
+	const string string_end = ";" + Comment + ";" + Colour + ";" + Modifiers.ToString() + ";";
 	switch (StepEnum)
 	{
 		case e_never_idle:
@@ -57,57 +58,57 @@ string StepParameters::ToString()
 		case e_keep_walking:
 		case e_pause:
 		case e_save:
-			return Step + ";" + ";" + ";" + ";" + ";" + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + ";" + ";" + ";" + ";" + ";" + ";" + ";" + string_end;
 
 		case e_stop:
 		case e_game_speed:
 		case e_idle:
 		case e_pick_up:
-			return Step + ";" + ";" + ";" + Amount + ";" + ";" + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + ";" + ";" + Amount + ";" + ";" + ";" + ";" + ";" + string_end;
 
 		case e_build:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_craft:
-			return Step + ";" + ";" + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + ";" + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_recipe:
 		case e_filter:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_limit:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_rotate:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_mine:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_priority:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + PriorityIn + "," + PriorityOut + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + PriorityIn + "," + PriorityOut + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		[[likely]] case e_put:
 		[[likely]] case e_take:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + FromInto + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + FromInto + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_launch:
 		[[likely]] case e_walk:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + ";" + ";" + ";" + string_end;
 
 		case e_tech:
-			return Step + ";" + ";" + ";" + ";" + Item + ";" + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + ";" + ";" + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_drop:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + ";" + ";" + string_end;
 
 		case e_shoot:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + ";" + ";" + ";" + string_end;
 		case e_throw:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + ";" + ";" + ";" + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		default:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + ";" + Comment + ";" + Colour + ";" + Modifiers + ";";
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 	}
 }
 

--- a/src/Structures/StepParameters.h
+++ b/src/Structures/StepParameters.h
@@ -6,6 +6,7 @@
 #include "Building.h"
 #include "StepType.h"
 #include "Orientation.h"
+#include "StepModifiers.h"
 
 using std::string;
 using std::ofstream;
@@ -23,7 +24,7 @@ struct StepParameters
 	int Buildings;
 	int BuildingIndex;
 
-	string Modifiers;
+	StepModifiers Modifiers;
 
 	Orientation OrientationEnum;
 	StepType StepEnum;

--- a/src/TAS save file/OpenTas.cpp
+++ b/src/TAS save file/OpenTas.cpp
@@ -171,7 +171,7 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 		step.Buildings = segments[8] != "" ? stoi(segments[8]) : 1;
 		step.Comment = segment_size == step_segment_size || segment_size == step_segment_size_without_colour ? segments[9] : "";
 		step.Colour = segment_size == step_segment_size ? segments[10] : "";
-		step.Modifiers = segment_size == step_segment_size ? segments[11] : "";
+		step.Modifiers.FromString(segment_size == step_segment_size ? segments[11] : "");
 		
 		if (step.Step == "Start")
 		{


### PR DESCRIPTION
### Background
I do not like the StepParameters struct extensive use of strings as a base. However the struct is used so many places that, making changes to it, easily becomes unmanageable. So I'll make changes in this smaller incremental format.

### Changes
- Changed base of modifiers to new struct StepModifiers. 
- Simplified button handlers for modifiers.
- Changed GenerateScript to use StepModifiers instead of it's own implementation. 
- Moved GenerateScript:Modifiers() to StepModifiers.

- Added a simple string_end to StepParameters::ToString.

- Added check for spin_x & spin_y is enabled before setting focus on them, to remove a runtime warning.
- Removed event.Skip() from On<Modifier>Clicked as it is irrelevant. I am not certain set focus is actually relevant though?

- Changed debug compilation to use MultiProcessorCompilation because it is way way faster.