### PR TITLE
Refactor priority

### DIFF
--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -298,7 +298,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 
 				SetBuildingAndOrientation(&steps[i]);
 
-				row_priority(currentStep, x_cord, y_cord, steps[i].PriorityIn, steps[i].PriorityOut, direction_to_build, amount_of_buildings, building_size, building, build_orientation, comment);
+				row_priority(currentStep, x_cord, y_cord, steps[i].priority, direction_to_build, amount_of_buildings, building_size, building, build_orientation, comment);
 				break;
 
 			case e_filter:
@@ -1187,10 +1187,10 @@ void GenerateScript::priority(string step, string action, string x_cord, string 
 	total_steps += 1;
 }
 
-void GenerateScript::row_priority(string step, string x_cord, string y_cord, string priority_in, string priority_out, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum, string comment)
+void GenerateScript::row_priority(string step, string x_cord, string y_cord, PriorityStruct _priority, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum, string comment)
 {
-	priority_in = convert_string(priority_in);
-	priority_out = convert_string(priority_out);
+	priority_in = convert_string(Priority::Names[_priority.input]);
+	priority_out = convert_string(Priority::Names[_priority.output]);
 
 	priority(step, "1", x_cord, y_cord, priority_in, priority_out, building, OrientationEnum, comment);
 

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -187,7 +187,7 @@ private:
 	void row_limit(string step, string x_cord, string y_cord, string amount, string from, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum, string comment);
 
 	void priority(string step, string action, string x_cord, string y_cord, string priority_in, string priority_out, string building, string OrientationEnum, string comment = "");
-	void row_priority(string step, string x_cord, string y_cord, string priority_in, string priority_out, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum, string comment);
+	void row_priority(string step, string x_cord, string y_cord, PriorityStruct _priority, string direction, string number_of_buildings, string building_size, string building, string OrientationEnum, string comment);
 
 	void filter(string step, string action, string x_cord, string y_cord, string item, string amount, string type, string building, string OrientationEnum, string comment = "");
 	void row_filter(string step, string x_cord, string y_cord, string item, string amount, string type, string direction_to_build, string number_of_buildings, string building_size, string building, string OrientationEnum, string comment);

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -107,15 +107,7 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 				break;
 
 			case e_priority:
-				position = step.Orientation.find(",");
-				step.PriorityIn = step.Orientation.substr(0, position);
-				step.PriorityOut = Capitalize(step.Orientation.substr(position + 1));
-
-				if (step.PriorityOut[0] == ' ')
-				{
-					step.PriorityOut = Capitalize(step.PriorityOut.substr(1));
-				}
-
+				step.priority.FromString(step.Orientation);
 				step.Orientation = "";
 
 				// Only here to populate extra parameters in step. Actual validation will be done on script generation

--- a/src/Structures/Priority.h
+++ b/src/Structures/Priority.h
@@ -1,24 +1,55 @@
 #pragma once
 
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include <string>
 
-enum INPUT_OUTPUT
+namespace Priority
 {
-	LEFT, NONE, RIGHT
+	enum Type
+	{
+		LEFT, NONE, RIGHT
+	};
+
+	static const std::vector<std::string> Names =
+	{
+		"Left",
+		"None",
+		"Right"
+	};
+
+	static inline std::unordered_map<std::string, Type> MapNameToType =
+	{
+		{Names[0], LEFT},
+		{Names[1], NONE},
+		{Names[2], RIGHT},
+
+		// lowercase copy
+		{"left", LEFT},
+		{"none", NONE},
+		{"right", RIGHT},
+	};
 };
 
-static const std::vector<std::string> input_output =
+// Merges a pair of priorities
+struct PriorityStruct
 {
-	"Left",
-	"None",
-	"Right"
-};
+	Priority::Type input = Priority::NONE;
+	Priority::Type output = Priority::NONE;
 
-static inline std::map<std::string, INPUT_OUTPUT> map_input_output =
-{
-	{input_output[0], LEFT},
-	{input_output[1], NONE},
-	{input_output[2], RIGHT}
+	std::string ToString()
+	{
+		return Priority::Names[input] + "," + Priority::Names[output];
+	}
+
+	void FromString(std::string str)
+	{
+		size_t pos = str.find(',');
+
+		auto in = Priority::MapNameToType.find(str.substr(0, pos));
+		auto out = Priority::MapNameToType.find(str.substr(pos + 1, str.size()));
+
+		input = in != Priority::MapNameToType.end() ? in->second : Priority::NONE;
+		output = out != Priority::MapNameToType.end() ? out->second : Priority::NONE;
+	}
 };

--- a/src/Structures/StepParameters.cpp
+++ b/src/Structures/StepParameters.cpp
@@ -86,7 +86,7 @@ string StepParameters::ToString()
 			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_priority:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + PriorityIn + "," + PriorityOut + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + priority.ToString() + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		[[likely]] case e_put:
 		[[likely]] case e_take:

--- a/src/Structures/StepParameters.h
+++ b/src/Structures/StepParameters.h
@@ -6,6 +6,7 @@
 #include "Building.h"
 #include "StepType.h"
 #include "Orientation.h"
+#include "Priority.h"
 #include "StepModifiers.h"
 
 using std::string;
@@ -35,8 +36,7 @@ struct StepParameters
 	string FromInto;
 	string Orientation;
 	string Direction;
-	string PriorityIn;
-	string PriorityOut;
+	PriorityStruct priority;
 	string Comment;
 	string Colour;
 

--- a/src/TAS save file/OpenTas.cpp
+++ b/src/TAS save file/OpenTas.cpp
@@ -200,15 +200,7 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 				break;
 
 			case e_priority:
-				position = step.Orientation.find(",");
-				step.PriorityIn = step.Orientation.substr(0, position);
-				step.PriorityOut = Capitalize(step.Orientation.substr(position + 1));
-
-				if (step.PriorityOut[0] == ' ')
-				{
-					step.PriorityOut = Capitalize(step.PriorityOut.substr(1));
-				}
-
+				step.priority.FromString(step.Orientation);
 				step.Orientation = "";
 
 				// Only here to populate extra parameters in step. Actual validation will be done on script generation
@@ -354,15 +346,7 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 				break;
 
 			case e_priority:
-				position = step.Orientation.find(",");
-				step.PriorityIn = step.Orientation.substr(0, position);
-				step.PriorityOut = Capitalize(step.Orientation.substr(position + 1));
-
-				if (step.PriorityOut[0] == ' ')
-				{
-					step.PriorityOut = Capitalize(step.PriorityOut.substr(1));
-				}
-
+				step.priority.FromString(step.Orientation);
 				step.Orientation = "";
 				break;
 
@@ -491,15 +475,7 @@ bool OpenTas::extract_templates(std::ifstream& file, DialogProgressBar* dialog_p
 				break;
 
 			case e_priority:
-				position = step.Orientation.find(",");
-				step.PriorityIn = step.Orientation.substr(0, position);
-				step.PriorityOut = Capitalize(step.Orientation.substr(position + 1));
-
-				if (step.PriorityOut[0] == ' ')
-				{
-					step.PriorityOut = Capitalize(step.PriorityOut.substr(1));
-				}
-
+				step.priority.FromString(step.Orientation);
 				step.Orientation = "";
 				break;
 

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -74,7 +74,7 @@ cMain::cMain() : GUI_Base(nullptr, wxID_ANY, window_title, wxPoint(30, 30), wxSi
 		building_orientation_choices.Add(s);
 	}
 
-	for (auto& s : input_output)
+	for (auto& s : Priority::Names)
 	{
 		input_output_choices.Add(s);
 	}
@@ -2018,8 +2018,8 @@ void cMain::UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event, bool c
 	if (parameters & amount) spin_amount->SetValue(gridEntry->Amount);
 	if (parameters & item) cmb_item->SetValue(gridEntry->Item);
 	if (parameters & from_to) cmb_from_into->SetValue(gridEntry->BuildingOrientation);
-	if (parameters & input) radio_input->Select(map_input_output[OrientationEnum.substr(0, pos)]);
-	if (parameters & output) radio_output->Select(map_input_output[OrientationEnum.substr(pos + 1)]);
+	if (parameters & input) radio_input->Select(Priority::MapNameToType[OrientationEnum.substr(0, pos)]);
+	if (parameters & output) radio_output->Select(Priority::MapNameToType[OrientationEnum.substr(pos + 1)]);
 	if (parameters & building_orientation) cmb_building_orientation->SetValue(gridEntry->BuildingOrientation);
 	if (parameters & direction_to_build) cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
 	if (parameters & building_size) spin_building_size->SetValue(gridEntry->BuildingSize);
@@ -2124,8 +2124,8 @@ StepParameters cMain::ExtractStepParameters()
 	stepParameters.Direction = Capitalize(cmb_direction_to_build->GetValue());
 	stepParameters.Size = spin_building_size->GetValue();
 	stepParameters.Buildings = spin_building_amount->GetValue();
-	stepParameters.PriorityIn = input_output[radio_input->GetSelection()];
-	stepParameters.PriorityOut = input_output[radio_output->GetSelection()];
+	stepParameters.priority.input = (Priority::Type) radio_input->GetSelection();
+	stepParameters.priority.output = (Priority::Type) radio_output->GetSelection();
 	stepParameters.Comment = txt_comment->GetValue().ToStdString();
 
 	stepParameters.Modifiers = {
@@ -2319,7 +2319,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 		case e_priority:
 			gridEntry.X = std::to_string(stepParameters->X);
 			gridEntry.Y = std::to_string(stepParameters->Y);
-			gridEntry.BuildingOrientation = stepParameters->PriorityIn + "," + stepParameters->PriorityOut;
+			gridEntry.BuildingOrientation = stepParameters->priority.ToString();
 			gridEntry.DirectionToBuild = stepParameters->Direction;
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);


### PR DESCRIPTION
- Moved priority "stuff" into a new namespace priority. 
- Changed the names priority's members.
- Added lowercase entries into priority string map.
- Changed priority string map to unordered_map.
- Added PriorityStruct that merges 2 priority.
- Changed StepParameters::PriorityIn & StepParameters::PriorityOut to PriorityStruct.

### PriorityStruct
Given that priority will always appear in pairs, it felt natural to create a struct for that.
The struct has been extended with ToString and FromString to simplify string operations in the rest of the app.

### Priority namespace
A namespace has been added, which allows for simple names such as "Type" and it also hides priority for most of the app where it doesn't matter.