### PR TITLE
Template overhaul

### DIFF
--- a/src/Factorio-TAS-Generator.vcxproj
+++ b/src/Factorio-TAS-Generator.vcxproj
@@ -180,6 +180,7 @@
     <ClCompile Include="Structures\StepParameters.cpp" />
     <ClCompile Include="TAS save file\OpenTas.cpp" />
     <ClCompile Include="TAS save file\SaveTas.cpp" />
+    <ClCompile Include="TemplatePage.cpp" />
     <ClCompile Include="TypePanel.cpp" />
     <ClCompile Include="WalkPanel.cpp" />
   </ItemGroup>

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -7340,98 +7340,36 @@
                         <property name="window_style">wxTAB_TRAVERSAL</property>
                         <object class="wxBoxSizer" expanded="1">
                             <property name="minimum_size"></property>
-                            <property name="name">bSizer5612</property>
+                            <property name="name">template_sizer</property>
                             <property name="orient">wxVERTICAL</property>
                             <property name="permission">none</property>
-                            <object class="sizeritem" expanded="0">
+                            <object class="sizeritem" expanded="1">
                                 <property name="border">5</property>
                                 <property name="flag">wxEXPAND</property>
                                 <property name="proportion">1</property>
-                                <object class="wxBoxSizer" expanded="0">
+                                <object class="wxBoxSizer" expanded="1">
                                     <property name="minimum_size"></property>
-                                    <property name="name">bSizer102</property>
+                                    <property name="name">template_control_sizer</property>
                                     <property name="orient">wxHORIZONTAL</property>
                                     <property name="permission">none</property>
-                                    <object class="sizeritem" expanded="0">
+                                    <object class="sizeritem" expanded="1">
                                         <property name="border">5</property>
                                         <property name="flag"></property>
                                         <property name="proportion">1</property>
-                                        <object class="wxBoxSizer" expanded="0">
-                                            <property name="minimum_size">612,-1</property>
-                                            <property name="name">bSizer103</property>
+                                        <object class="wxBoxSizer" expanded="1">
+                                            <property name="minimum_size">500,-1</property>
+                                            <property name="name">template_control_left_sizer</property>
                                             <property name="orient">wxVERTICAL</property>
                                             <property name="permission">none</property>
-                                            <object class="sizeritem" expanded="0">
+                                            <object class="sizeritem" expanded="1">
                                                 <property name="border">5</property>
                                                 <property name="flag">wxALIGN_LEFT</property>
                                                 <property name="proportion">1</property>
-                                                <object class="wxBoxSizer" expanded="0">
+                                                <object class="wxBoxSizer" expanded="1">
                                                     <property name="minimum_size"></property>
-                                                    <property name="name">bSizer126</property>
+                                                    <property name="name">template_template_control_sizer</property>
                                                     <property name="orient">wxHORIZONTAL</property>
                                                     <property name="permission">none</property>
-                                                    <object class="sizeritem" expanded="0">
-                                                        <property name="border">5</property>
-                                                        <property name="flag">wxALIGN_CENTER|wxALL</property>
-                                                        <property name="proportion">0</property>
-                                                        <object class="wxStaticText" expanded="0">
-                                                            <property name="BottomDockable">1</property>
-                                                            <property name="LeftDockable">1</property>
-                                                            <property name="RightDockable">1</property>
-                                                            <property name="TopDockable">1</property>
-                                                            <property name="aui_layer"></property>
-                                                            <property name="aui_name"></property>
-                                                            <property name="aui_position"></property>
-                                                            <property name="aui_row"></property>
-                                                            <property name="best_size"></property>
-                                                            <property name="bg"></property>
-                                                            <property name="caption"></property>
-                                                            <property name="caption_visible">1</property>
-                                                            <property name="center_pane">0</property>
-                                                            <property name="close_button">1</property>
-                                                            <property name="context_help"></property>
-                                                            <property name="context_menu">1</property>
-                                                            <property name="default_pane">0</property>
-                                                            <property name="dock">Dock</property>
-                                                            <property name="dock_fixed">0</property>
-                                                            <property name="docking">Left</property>
-                                                            <property name="drag_accept_files">0</property>
-                                                            <property name="enabled">1</property>
-                                                            <property name="fg"></property>
-                                                            <property name="floatable">1</property>
-                                                            <property name="font"></property>
-                                                            <property name="gripper">0</property>
-                                                            <property name="hidden">0</property>
-                                                            <property name="id">wxID_ANY</property>
-                                                            <property name="label">Template:</property>
-                                                            <property name="markup">0</property>
-                                                            <property name="max_size"></property>
-                                                            <property name="maximize_button">0</property>
-                                                            <property name="maximum_size"></property>
-                                                            <property name="min_size"></property>
-                                                            <property name="minimize_button">0</property>
-                                                            <property name="minimum_size"></property>
-                                                            <property name="moveable">1</property>
-                                                            <property name="name">label_choose_template</property>
-                                                            <property name="pane_border">1</property>
-                                                            <property name="pane_position"></property>
-                                                            <property name="pane_size"></property>
-                                                            <property name="permission">protected</property>
-                                                            <property name="pin_button">1</property>
-                                                            <property name="pos"></property>
-                                                            <property name="resize">Resizable</property>
-                                                            <property name="show">1</property>
-                                                            <property name="size">50,-1</property>
-                                                            <property name="style"></property>
-                                                            <property name="subclass">; ; forward_declare</property>
-                                                            <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
-                                                            <property name="window_extra_style"></property>
-                                                            <property name="window_name"></property>
-                                                            <property name="window_style"></property>
-                                                            <property name="wrap">-1</property>
-                                                        </object>
-                                                    </object>
                                                     <object class="sizeritem" expanded="0">
                                                         <property name="border">5</property>
                                                         <property name="flag">wxALIGN_CENTER|wxALL</property>
@@ -7471,7 +7409,7 @@
                                                             <property name="maximum_size"></property>
                                                             <property name="min_size"></property>
                                                             <property name="minimize_button">0</property>
-                                                            <property name="minimum_size">195,-1</property>
+                                                            <property name="minimum_size">245,-1</property>
                                                             <property name="moveable">1</property>
                                                             <property name="name">cmb_choose_template</property>
                                                             <property name="pane_border">1</property>
@@ -7487,7 +7425,7 @@
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Use to select and load a template,&#x0A;Or to specify the name of a new template.</property>
                                                             <property name="validator_data_type"></property>
                                                             <property name="validator_style">wxFILTER_NONE</property>
                                                             <property name="validator_type">wxDefaultValidator</property>
@@ -7539,7 +7477,7 @@
                                                             <property name="gripper">0</property>
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
-                                                            <property name="label">New Template</property>
+                                                            <property name="label">New</property>
                                                             <property name="margins"></property>
                                                             <property name="markup">0</property>
                                                             <property name="max_size"></property>
@@ -7560,11 +7498,11 @@
                                                             <property name="pressed"></property>
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
-                                                            <property name="size">105,-1</property>
+                                                            <property name="size">-1,-1</property>
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Create a new template with name from box on the left. </property>
                                                             <property name="validator_data_type"></property>
                                                             <property name="validator_style">wxFILTER_NONE</property>
                                                             <property name="validator_type">wxDefaultValidator</property>
@@ -7614,7 +7552,7 @@
                                                             <property name="gripper">0</property>
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
-                                                            <property name="label">Delete Template</property>
+                                                            <property name="label">Delete</property>
                                                             <property name="margins"></property>
                                                             <property name="markup">0</property>
                                                             <property name="max_size"></property>
@@ -7635,11 +7573,11 @@
                                                             <property name="pressed"></property>
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
-                                                            <property name="size">105,-1</property>
+                                                            <property name="size">-1,-1</property>
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Delete this template and it&apos;s content.</property>
                                                             <property name="validator_data_type"></property>
                                                             <property name="validator_style">wxFILTER_NONE</property>
                                                             <property name="validator_type">wxDefaultValidator</property>
@@ -7648,19 +7586,95 @@
                                                             <property name="window_name"></property>
                                                             <property name="window_style"></property>
                                                             <event name="OnButtonClick">OnDeleteTemplateClicked</event>
+                                                            <event name="OnRightUp">OnDeleteTemplateRightClicked</event>
                                                         </object>
                                                     </object>
                                                 </object>
                                             </object>
-                                            <object class="sizeritem" expanded="0">
+                                            <object class="sizeritem" expanded="1">
                                                 <property name="border">5</property>
                                                 <property name="flag">wxALIGN_LEFT</property>
                                                 <property name="proportion">1</property>
-                                                <object class="wxBoxSizer" expanded="0">
+                                                <object class="wxBoxSizer" expanded="1">
                                                     <property name="minimum_size"></property>
-                                                    <property name="name">bSizer1002</property>
+                                                    <property name="name">template_step_control_sizer</property>
                                                     <property name="orient">wxHORIZONTAL</property>
                                                     <property name="permission">none</property>
+                                                    <object class="sizeritem" expanded="1">
+                                                        <property name="border">5</property>
+                                                        <property name="flag">wxALL</property>
+                                                        <property name="proportion">0</property>
+                                                        <object class="wxButton" expanded="1">
+                                                            <property name="BottomDockable">1</property>
+                                                            <property name="LeftDockable">1</property>
+                                                            <property name="RightDockable">1</property>
+                                                            <property name="TopDockable">1</property>
+                                                            <property name="aui_layer"></property>
+                                                            <property name="aui_name"></property>
+                                                            <property name="aui_position"></property>
+                                                            <property name="aui_row"></property>
+                                                            <property name="auth_needed">0</property>
+                                                            <property name="best_size"></property>
+                                                            <property name="bg"></property>
+                                                            <property name="bitmap"></property>
+                                                            <property name="caption"></property>
+                                                            <property name="caption_visible">1</property>
+                                                            <property name="center_pane">0</property>
+                                                            <property name="close_button">1</property>
+                                                            <property name="context_help"></property>
+                                                            <property name="context_menu">1</property>
+                                                            <property name="current"></property>
+                                                            <property name="default">0</property>
+                                                            <property name="default_pane">0</property>
+                                                            <property name="disabled"></property>
+                                                            <property name="dock">Dock</property>
+                                                            <property name="dock_fixed">0</property>
+                                                            <property name="docking">Left</property>
+                                                            <property name="drag_accept_files">0</property>
+                                                            <property name="enabled">1</property>
+                                                            <property name="fg"></property>
+                                                            <property name="floatable">1</property>
+                                                            <property name="focus"></property>
+                                                            <property name="font"></property>
+                                                            <property name="gripper">0</property>
+                                                            <property name="hidden">0</property>
+                                                            <property name="id">wxID_ANY</property>
+                                                            <property name="label">Add</property>
+                                                            <property name="margins"></property>
+                                                            <property name="markup">0</property>
+                                                            <property name="max_size"></property>
+                                                            <property name="maximize_button">0</property>
+                                                            <property name="maximum_size"></property>
+                                                            <property name="min_size"></property>
+                                                            <property name="minimize_button">0</property>
+                                                            <property name="minimum_size"></property>
+                                                            <property name="moveable">1</property>
+                                                            <property name="name">btn_template_add_step</property>
+                                                            <property name="pane_border">1</property>
+                                                            <property name="pane_position"></property>
+                                                            <property name="pane_size"></property>
+                                                            <property name="permission">protected</property>
+                                                            <property name="pin_button">1</property>
+                                                            <property name="pos"></property>
+                                                            <property name="position"></property>
+                                                            <property name="pressed"></property>
+                                                            <property name="resize">Resizable</property>
+                                                            <property name="show">1</property>
+                                                            <property name="size"></property>
+                                                            <property name="style"></property>
+                                                            <property name="subclass">; ; forward_declare</property>
+                                                            <property name="toolbar_pane">0</property>
+                                                            <property name="tooltip">Adds a step using the step detail panel to this template.</property>
+                                                            <property name="validator_data_type"></property>
+                                                            <property name="validator_style">wxFILTER_NONE</property>
+                                                            <property name="validator_type">wxDefaultValidator</property>
+                                                            <property name="validator_variable"></property>
+                                                            <property name="window_extra_style"></property>
+                                                            <property name="window_name"></property>
+                                                            <property name="window_style"></property>
+                                                            <event name="OnButtonClick">OnTemplateAddStepClicked</event>
+                                                        </object>
+                                                    </object>
                                                     <object class="sizeritem" expanded="0">
                                                         <property name="border">5</property>
                                                         <property name="flag">wxALL</property>
@@ -7725,7 +7739,7 @@
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Update the select template step using inputs from the details panel.</property>
                                                             <property name="validator_data_type"></property>
                                                             <property name="validator_style">wxFILTER_NONE</property>
                                                             <property name="validator_type">wxDefaultValidator</property>
@@ -7800,7 +7814,7 @@
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Delete the selected template steps from this template.</property>
                                                             <property name="validator_data_type"></property>
                                                             <property name="validator_style">wxFILTER_NONE</property>
                                                             <property name="validator_type">wxDefaultValidator</property>
@@ -7850,7 +7864,7 @@
                                                             <property name="gripper">0</property>
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
-                                                            <property name="label">Move Up</property>
+                                                            <property name="label">Up</property>
                                                             <property name="margins"></property>
                                                             <property name="markup">0</property>
                                                             <property name="max_size"></property>
@@ -7875,7 +7889,7 @@
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Move this template step one row up.</property>
                                                             <property name="validator_data_type"></property>
                                                             <property name="validator_style">wxFILTER_NONE</property>
                                                             <property name="validator_type">wxDefaultValidator</property>
@@ -7925,7 +7939,7 @@
                                                             <property name="gripper">0</property>
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
-                                                            <property name="label">Move Down</property>
+                                                            <property name="label">Down</property>
                                                             <property name="margins"></property>
                                                             <property name="markup">0</property>
                                                             <property name="max_size"></property>
@@ -7950,7 +7964,7 @@
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Move this template step one row down.</property>
                                                             <property name="validator_data_type"></property>
                                                             <property name="validator_style">wxFILTER_NONE</property>
                                                             <property name="validator_type">wxDefaultValidator</property>
@@ -7967,7 +7981,7 @@
                                     </object>
                                     <object class="sizeritem" expanded="0">
                                         <property name="border">5</property>
-                                        <property name="flag">wxEXPAND | wxALL</property>
+                                        <property name="flag">wxALL|wxEXPAND</property>
                                         <property name="proportion">0</property>
                                         <object class="wxStaticLine" expanded="0">
                                             <property name="BottomDockable">1</property>
@@ -8024,203 +8038,181 @@
                                             <property name="window_style"></property>
                                         </object>
                                     </object>
-                                    <object class="sizeritem" expanded="0">
+                                    <object class="sizeritem" expanded="1">
                                         <property name="border">5</property>
                                         <property name="flag">wxEXPAND</property>
                                         <property name="proportion">0</property>
-                                        <object class="wxBoxSizer" expanded="0">
+                                        <object class="wxBoxSizer" expanded="1">
                                             <property name="minimum_size">-1,-1</property>
-                                            <property name="name">bSizer1041</property>
+                                            <property name="name">template_import_export_sizer</property>
                                             <property name="orient">wxVERTICAL</property>
                                             <property name="permission">none</property>
                                             <object class="sizeritem" expanded="0">
                                                 <property name="border">5</property>
-                                                <property name="flag"></property>
-                                                <property name="proportion">1</property>
-                                                <object class="wxBoxSizer" expanded="0">
+                                                <property name="flag">wxALL</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxButton" expanded="0">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="auth_needed">0</property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="bitmap"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="current"></property>
+                                                    <property name="default">0</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="disabled"></property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="drag_accept_files">0</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="focus"></property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="label">Import</property>
+                                                    <property name="margins"></property>
+                                                    <property name="markup">0</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
                                                     <property name="minimum_size"></property>
-                                                    <property name="name">bSizer1051</property>
-                                                    <property name="orient">wxHORIZONTAL</property>
-                                                    <property name="permission">none</property>
-                                                    <object class="sizeritem" expanded="0">
-                                                        <property name="border">5</property>
-                                                        <property name="flag">wxALL</property>
-                                                        <property name="proportion">0</property>
-                                                        <object class="wxButton" expanded="0">
-                                                            <property name="BottomDockable">1</property>
-                                                            <property name="LeftDockable">1</property>
-                                                            <property name="RightDockable">1</property>
-                                                            <property name="TopDockable">1</property>
-                                                            <property name="aui_layer"></property>
-                                                            <property name="aui_name"></property>
-                                                            <property name="aui_position"></property>
-                                                            <property name="aui_row"></property>
-                                                            <property name="auth_needed">0</property>
-                                                            <property name="best_size"></property>
-                                                            <property name="bg"></property>
-                                                            <property name="bitmap"></property>
-                                                            <property name="caption"></property>
-                                                            <property name="caption_visible">1</property>
-                                                            <property name="center_pane">0</property>
-                                                            <property name="close_button">1</property>
-                                                            <property name="context_help"></property>
-                                                            <property name="context_menu">1</property>
-                                                            <property name="current"></property>
-                                                            <property name="default">0</property>
-                                                            <property name="default_pane">0</property>
-                                                            <property name="disabled"></property>
-                                                            <property name="dock">Dock</property>
-                                                            <property name="dock_fixed">0</property>
-                                                            <property name="docking">Left</property>
-                                                            <property name="drag_accept_files">0</property>
-                                                            <property name="enabled">1</property>
-                                                            <property name="fg"></property>
-                                                            <property name="floatable">1</property>
-                                                            <property name="focus"></property>
-                                                            <property name="font"></property>
-                                                            <property name="gripper">0</property>
-                                                            <property name="hidden">0</property>
-                                                            <property name="id">wxID_ANY</property>
-                                                            <property name="label">Add to steps list</property>
-                                                            <property name="margins"></property>
-                                                            <property name="markup">0</property>
-                                                            <property name="max_size"></property>
-                                                            <property name="maximize_button">0</property>
-                                                            <property name="maximum_size"></property>
-                                                            <property name="min_size"></property>
-                                                            <property name="minimize_button">0</property>
-                                                            <property name="minimum_size"></property>
-                                                            <property name="moveable">1</property>
-                                                            <property name="name">btn_template_add_to_steps_list</property>
-                                                            <property name="pane_border">1</property>
-                                                            <property name="pane_position"></property>
-                                                            <property name="pane_size"></property>
-                                                            <property name="permission">protected</property>
-                                                            <property name="pin_button">1</property>
-                                                            <property name="pos"></property>
-                                                            <property name="position"></property>
-                                                            <property name="pressed"></property>
-                                                            <property name="resize">Resizable</property>
-                                                            <property name="show">1</property>
-                                                            <property name="size">125,-1</property>
-                                                            <property name="style"></property>
-                                                            <property name="subclass">; ; forward_declare</property>
-                                                            <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
-                                                            <property name="validator_data_type"></property>
-                                                            <property name="validator_style">wxFILTER_NONE</property>
-                                                            <property name="validator_type">wxDefaultValidator</property>
-                                                            <property name="validator_variable"></property>
-                                                            <property name="window_extra_style"></property>
-                                                            <property name="window_name"></property>
-                                                            <property name="window_style"></property>
-                                                            <event name="OnButtonClick">OnTemplateAddToStepsListClicked</event>
-                                                        </object>
-                                                    </object>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">btn_template_add_to_steps_list</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="position"></property>
+                                                    <property name="pressed"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size">-1,-1</property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass">; ; forward_declare</property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip">Moves a range of steps from the steps panel into this template.</property>
+                                                    <property name="validator_data_type"></property>
+                                                    <property name="validator_style">wxFILTER_NONE</property>
+                                                    <property name="validator_type">wxDefaultValidator</property>
+                                                    <property name="validator_variable"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                    <event name="OnButtonClick">OnTemplateAddToStepsListClicked</event>
                                                 </object>
                                             </object>
                                             <object class="sizeritem" expanded="0">
                                                 <property name="border">5</property>
-                                                <property name="flag"></property>
-                                                <property name="proportion">1</property>
-                                                <object class="wxBoxSizer" expanded="0">
+                                                <property name="flag">wxALL</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxButton" expanded="0">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="auth_needed">0</property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="bitmap"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="current"></property>
+                                                    <property name="default">0</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="disabled"></property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="drag_accept_files">0</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="focus"></property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="label">Export</property>
+                                                    <property name="margins"></property>
+                                                    <property name="markup">0</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
                                                     <property name="minimum_size"></property>
-                                                    <property name="name">bSizer1061</property>
-                                                    <property name="orient">wxHORIZONTAL</property>
-                                                    <property name="permission">none</property>
-                                                    <object class="sizeritem" expanded="0">
-                                                        <property name="border">5</property>
-                                                        <property name="flag">wxALL</property>
-                                                        <property name="proportion">0</property>
-                                                        <object class="wxButton" expanded="0">
-                                                            <property name="BottomDockable">1</property>
-                                                            <property name="LeftDockable">1</property>
-                                                            <property name="RightDockable">1</property>
-                                                            <property name="TopDockable">1</property>
-                                                            <property name="aui_layer"></property>
-                                                            <property name="aui_name"></property>
-                                                            <property name="aui_position"></property>
-                                                            <property name="aui_row"></property>
-                                                            <property name="auth_needed">0</property>
-                                                            <property name="best_size"></property>
-                                                            <property name="bg"></property>
-                                                            <property name="bitmap"></property>
-                                                            <property name="caption"></property>
-                                                            <property name="caption_visible">1</property>
-                                                            <property name="center_pane">0</property>
-                                                            <property name="close_button">1</property>
-                                                            <property name="context_help"></property>
-                                                            <property name="context_menu">1</property>
-                                                            <property name="current"></property>
-                                                            <property name="default">0</property>
-                                                            <property name="default_pane">0</property>
-                                                            <property name="disabled"></property>
-                                                            <property name="dock">Dock</property>
-                                                            <property name="dock_fixed">0</property>
-                                                            <property name="docking">Left</property>
-                                                            <property name="drag_accept_files">0</property>
-                                                            <property name="enabled">1</property>
-                                                            <property name="fg"></property>
-                                                            <property name="floatable">1</property>
-                                                            <property name="focus"></property>
-                                                            <property name="font"></property>
-                                                            <property name="gripper">0</property>
-                                                            <property name="hidden">0</property>
-                                                            <property name="id">wxID_ANY</property>
-                                                            <property name="label">Add from steps list</property>
-                                                            <property name="margins"></property>
-                                                            <property name="markup">0</property>
-                                                            <property name="max_size"></property>
-                                                            <property name="maximize_button">0</property>
-                                                            <property name="maximum_size"></property>
-                                                            <property name="min_size"></property>
-                                                            <property name="minimize_button">0</property>
-                                                            <property name="minimum_size"></property>
-                                                            <property name="moveable">1</property>
-                                                            <property name="name">btn_template_add_from_steps_list</property>
-                                                            <property name="pane_border">1</property>
-                                                            <property name="pane_position"></property>
-                                                            <property name="pane_size"></property>
-                                                            <property name="permission">protected</property>
-                                                            <property name="pin_button">1</property>
-                                                            <property name="pos"></property>
-                                                            <property name="position"></property>
-                                                            <property name="pressed"></property>
-                                                            <property name="resize">Resizable</property>
-                                                            <property name="show">1</property>
-                                                            <property name="size">125,-1</property>
-                                                            <property name="style"></property>
-                                                            <property name="subclass">; ; forward_declare</property>
-                                                            <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
-                                                            <property name="validator_data_type"></property>
-                                                            <property name="validator_style">wxFILTER_NONE</property>
-                                                            <property name="validator_type">wxDefaultValidator</property>
-                                                            <property name="validator_variable"></property>
-                                                            <property name="window_extra_style"></property>
-                                                            <property name="window_name"></property>
-                                                            <property name="window_style"></property>
-                                                            <event name="OnButtonClick">OnTemplateAddFromStepsListClicked</event>
-                                                        </object>
-                                                    </object>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">btn_template_add_from_steps_list</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="position"></property>
+                                                    <property name="pressed"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size">-1,-1</property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass">; ; forward_declare</property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip">Moves the selected range of template steps or all template steps from this template into the steps page. Using the transformations on the right.</property>
+                                                    <property name="validator_data_type"></property>
+                                                    <property name="validator_style">wxFILTER_NONE</property>
+                                                    <property name="validator_type">wxDefaultValidator</property>
+                                                    <property name="validator_variable"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                    <event name="OnButtonClick">OnTemplateAddFromStepsListClicked</event>
                                                 </object>
                                             </object>
                                         </object>
                                     </object>
-                                    <object class="sizeritem" expanded="0">
+                                    <object class="sizeritem" expanded="1">
                                         <property name="border">5</property>
                                         <property name="flag"></property>
                                         <property name="proportion">0</property>
-                                        <object class="wxBoxSizer" expanded="0">
+                                        <object class="wxBoxSizer" expanded="1">
                                             <property name="minimum_size">-1,-1</property>
-                                            <property name="name">bSizer1042</property>
+                                            <property name="name">template_amount_sizer</property>
                                             <property name="orient">wxVERTICAL</property>
                                             <property name="permission">none</property>
-                                            <object class="sizeritem" expanded="0">
+                                            <object class="sizeritem" expanded="1">
                                                 <property name="border">5</property>
                                                 <property name="flag"></property>
                                                 <property name="proportion">1</property>
-                                                <object class="wxBoxSizer" expanded="0">
+                                                <object class="wxBoxSizer" expanded="1">
                                                     <property name="minimum_size"></property>
                                                     <property name="name">bSizer1052</property>
                                                     <property name="orient">wxHORIZONTAL</property>
@@ -8258,7 +8250,7 @@
                                                             <property name="gripper">0</property>
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
-                                                            <property name="label">Amount-Offset:</property>
+                                                            <property name="label">Offset:</property>
                                                             <property name="markup">0</property>
                                                             <property name="max_size"></property>
                                                             <property name="maximize_button">0</property>
@@ -8276,7 +8268,7 @@
                                                             <property name="pos"></property>
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
-                                                            <property name="size">85,-1</property>
+                                                            <property name="size">55,-1</property>
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
@@ -8340,10 +8332,10 @@
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
                                                             <property name="size">50,-1</property>
-                                                            <property name="style">wxSP_ARROW_KEYS</property>
+                                                            <property name="style">wxALIGN_RIGHT|wxSP_ARROW_KEYS</property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Used to specify an amount off-set to the whole range of exported steps.&#x0A;This is applied after multiplication.</property>
                                                             <property name="value"></property>
                                                             <property name="window_extra_style"></property>
                                                             <property name="window_name"></property>
@@ -8352,11 +8344,11 @@
                                                     </object>
                                                 </object>
                                             </object>
-                                            <object class="sizeritem" expanded="0">
+                                            <object class="sizeritem" expanded="1">
                                                 <property name="border">5</property>
                                                 <property name="flag"></property>
                                                 <property name="proportion">1</property>
-                                                <object class="wxBoxSizer" expanded="0">
+                                                <object class="wxBoxSizer" expanded="1">
                                                     <property name="minimum_size"></property>
                                                     <property name="name">bSizer1062</property>
                                                     <property name="orient">wxHORIZONTAL</property>
@@ -8394,7 +8386,7 @@
                                                             <property name="gripper">0</property>
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
-                                                            <property name="label">Amount-Multi:</property>
+                                                            <property name="label">Multiplier:</property>
                                                             <property name="markup">0</property>
                                                             <property name="max_size"></property>
                                                             <property name="maximize_button">0</property>
@@ -8412,7 +8404,7 @@
                                                             <property name="pos"></property>
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
-                                                            <property name="size">85,-1</property>
+                                                            <property name="size">55,-1</property>
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
@@ -8456,12 +8448,12 @@
                                                             <property name="gripper">0</property>
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
-                                                            <property name="initial">0</property>
-                                                            <property name="max">10000</property>
+                                                            <property name="initial">1</property>
+                                                            <property name="max">100</property>
                                                             <property name="max_size"></property>
                                                             <property name="maximize_button">0</property>
                                                             <property name="maximum_size"></property>
-                                                            <property name="min">-10000</property>
+                                                            <property name="min">0</property>
                                                             <property name="min_size"></property>
                                                             <property name="minimize_button">0</property>
                                                             <property name="minimum_size"></property>
@@ -8476,10 +8468,10 @@
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
                                                             <property name="size">50,-1</property>
-                                                            <property name="style">wxSP_ARROW_KEYS</property>
+                                                            <property name="style">wxALIGN_RIGHT|wxSP_ARROW_KEYS</property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Used to specify an amount multiplication to the whole range of exported steps.&#x0A;This is applied before offset.</property>
                                                             <property name="value"></property>
                                                             <property name="window_extra_style"></property>
                                                             <property name="window_name"></property>
@@ -8490,20 +8482,79 @@
                                             </object>
                                         </object>
                                     </object>
-                                    <object class="sizeritem" expanded="0">
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag">wxEXPAND | wxALL</property>
+                                        <property name="proportion">0</property>
+                                        <object class="wxStaticLine" expanded="1">
+                                            <property name="BottomDockable">1</property>
+                                            <property name="LeftDockable">1</property>
+                                            <property name="RightDockable">1</property>
+                                            <property name="TopDockable">1</property>
+                                            <property name="aui_layer"></property>
+                                            <property name="aui_name"></property>
+                                            <property name="aui_position"></property>
+                                            <property name="aui_row"></property>
+                                            <property name="best_size"></property>
+                                            <property name="bg"></property>
+                                            <property name="caption"></property>
+                                            <property name="caption_visible">1</property>
+                                            <property name="center_pane">0</property>
+                                            <property name="close_button">1</property>
+                                            <property name="context_help"></property>
+                                            <property name="context_menu">1</property>
+                                            <property name="default_pane">0</property>
+                                            <property name="dock">Dock</property>
+                                            <property name="dock_fixed">0</property>
+                                            <property name="docking">Left</property>
+                                            <property name="drag_accept_files">0</property>
+                                            <property name="enabled">1</property>
+                                            <property name="fg"></property>
+                                            <property name="floatable">1</property>
+                                            <property name="font"></property>
+                                            <property name="gripper">0</property>
+                                            <property name="hidden">0</property>
+                                            <property name="id">wxID_ANY</property>
+                                            <property name="max_size"></property>
+                                            <property name="maximize_button">0</property>
+                                            <property name="maximum_size"></property>
+                                            <property name="min_size"></property>
+                                            <property name="minimize_button">0</property>
+                                            <property name="minimum_size"></property>
+                                            <property name="moveable">1</property>
+                                            <property name="name">m_staticline2</property>
+                                            <property name="pane_border">1</property>
+                                            <property name="pane_position"></property>
+                                            <property name="pane_size"></property>
+                                            <property name="permission">protected</property>
+                                            <property name="pin_button">1</property>
+                                            <property name="pos"></property>
+                                            <property name="resize">Resizable</property>
+                                            <property name="show">1</property>
+                                            <property name="size"></property>
+                                            <property name="style">wxLI_VERTICAL</property>
+                                            <property name="subclass">; ; forward_declare</property>
+                                            <property name="toolbar_pane">0</property>
+                                            <property name="tooltip"></property>
+                                            <property name="window_extra_style"></property>
+                                            <property name="window_name"></property>
+                                            <property name="window_style"></property>
+                                        </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="1">
                                         <property name="border">5</property>
                                         <property name="flag"></property>
                                         <property name="proportion">0</property>
-                                        <object class="wxBoxSizer" expanded="0">
+                                        <object class="wxBoxSizer" expanded="1">
                                             <property name="minimum_size">-1,-1</property>
-                                            <property name="name">bSizer104</property>
+                                            <property name="name">template_coordinate_sizer</property>
                                             <property name="orient">wxVERTICAL</property>
                                             <property name="permission">none</property>
-                                            <object class="sizeritem" expanded="0">
+                                            <object class="sizeritem" expanded="1">
                                                 <property name="border">5</property>
                                                 <property name="flag"></property>
                                                 <property name="proportion">1</property>
-                                                <object class="wxBoxSizer" expanded="0">
+                                                <object class="wxBoxSizer" expanded="1">
                                                     <property name="minimum_size"></property>
                                                     <property name="name">bSizer105</property>
                                                     <property name="orient">wxHORIZONTAL</property>
@@ -8541,7 +8592,7 @@
                                                             <property name="gripper">0</property>
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
-                                                            <property name="label">X-Offset:</property>
+                                                            <property name="label">X:</property>
                                                             <property name="markup">0</property>
                                                             <property name="max_size"></property>
                                                             <property name="maximize_button">0</property>
@@ -8559,7 +8610,7 @@
                                                             <property name="pos"></property>
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
-                                                            <property name="size">50,-1</property>
+                                                            <property name="size">15,-1</property>
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
@@ -8604,11 +8655,11 @@
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
                                                             <property name="initial">0</property>
-                                                            <property name="max">10000</property>
+                                                            <property name="max">1000000</property>
                                                             <property name="max_size"></property>
                                                             <property name="maximize_button">0</property>
                                                             <property name="maximum_size"></property>
-                                                            <property name="min">-10000</property>
+                                                            <property name="min">-1000000</property>
                                                             <property name="min_size"></property>
                                                             <property name="minimize_button">0</property>
                                                             <property name="minimum_size"></property>
@@ -8622,11 +8673,11 @@
                                                             <property name="pos"></property>
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
-                                                            <property name="size">50,-1</property>
-                                                            <property name="style">wxSP_ARROW_KEYS</property>
+                                                            <property name="size">65,-1</property>
+                                                            <property name="style">wxALIGN_RIGHT|wxSP_ARROW_KEYS</property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">X coordinate offset</property>
                                                             <property name="value"></property>
                                                             <property name="window_extra_style"></property>
                                                             <property name="window_name"></property>
@@ -8635,11 +8686,11 @@
                                                     </object>
                                                 </object>
                                             </object>
-                                            <object class="sizeritem" expanded="0">
+                                            <object class="sizeritem" expanded="1">
                                                 <property name="border">5</property>
                                                 <property name="flag"></property>
                                                 <property name="proportion">1</property>
-                                                <object class="wxBoxSizer" expanded="0">
+                                                <object class="wxBoxSizer" expanded="1">
                                                     <property name="minimum_size"></property>
                                                     <property name="name">bSizer106</property>
                                                     <property name="orient">wxHORIZONTAL</property>
@@ -8677,7 +8728,7 @@
                                                             <property name="gripper">0</property>
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
-                                                            <property name="label">Y-Offset:</property>
+                                                            <property name="label">Y:</property>
                                                             <property name="markup">0</property>
                                                             <property name="max_size"></property>
                                                             <property name="maximize_button">0</property>
@@ -8695,7 +8746,7 @@
                                                             <property name="pos"></property>
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
-                                                            <property name="size">50,-1</property>
+                                                            <property name="size">15,-1</property>
                                                             <property name="style"></property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
@@ -8740,11 +8791,11 @@
                                                             <property name="hidden">0</property>
                                                             <property name="id">wxID_ANY</property>
                                                             <property name="initial">0</property>
-                                                            <property name="max">10000</property>
+                                                            <property name="max">1000000</property>
                                                             <property name="max_size"></property>
                                                             <property name="maximize_button">0</property>
                                                             <property name="maximum_size"></property>
-                                                            <property name="min">-10000</property>
+                                                            <property name="min">-1000000</property>
                                                             <property name="min_size"></property>
                                                             <property name="minimize_button">0</property>
                                                             <property name="minimum_size"></property>
@@ -8758,17 +8809,156 @@
                                                             <property name="pos"></property>
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
-                                                            <property name="size">50,-1</property>
-                                                            <property name="style">wxSP_ARROW_KEYS</property>
+                                                            <property name="size">65,-1</property>
+                                                            <property name="style">wxALIGN_RIGHT|wxSP_ARROW_KEYS</property>
                                                             <property name="subclass">; ; forward_declare</property>
                                                             <property name="toolbar_pane">0</property>
-                                                            <property name="tooltip"></property>
+                                                            <property name="tooltip">Y coordinate offset</property>
                                                             <property name="value"></property>
                                                             <property name="window_extra_style"></property>
                                                             <property name="window_name"></property>
                                                             <property name="window_style"></property>
                                                         </object>
                                                     </object>
+                                                </object>
+                                            </object>
+                                        </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag"></property>
+                                        <property name="proportion">1</property>
+                                        <object class="wxBoxSizer" expanded="1">
+                                            <property name="minimum_size"></property>
+                                            <property name="name">template_advanced_sizer</property>
+                                            <property name="orient">wxVERTICAL</property>
+                                            <property name="permission">none</property>
+                                            <object class="sizeritem" expanded="1">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxBOTTOM|wxLEFT|wxTOP</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxSpinCtrl" expanded="1">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="drag_accept_files">0</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="initial">0</property>
+                                                    <property name="max">99</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="min">0</property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">spin_template_iterator</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size">68,-1</property>
+                                                    <property name="style">wxSP_ARROW_KEYS</property>
+                                                    <property name="subclass">; ; forward_declare</property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip">Coordinate offset multiplier (X,Y) when using Export.&#x0A;Calculated: (X,Y) + offset * multiplier&#x0A;&#x0A;This will auto increment when using Export.&#x0A;Set to 0 to not increment this will be interpreted as a multiplier of 1.</property>
+                                                    <property name="value"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                </object>
+                                            </object>
+                                            <object class="sizeritem" expanded="1">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxBOTTOM|wxLEFT|wxTOP</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxChoice" expanded="1">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="choices">&quot;Normal&quot; &quot;Left&quot; &quot;Reverse&quot; &quot;Right&quot;</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="drag_accept_files">0</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">choice_template_direction</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="selection">0</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size"></property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass">; ; forward_declare</property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip">Rotational transformation for Export.&#x0A;Each rotation transform the export template 90 degrees from the normal axis.&#x0A;&#x0A;Calculated: ( (X,Y) + offset * multiplier ) * v90degree</property>
+                                                    <property name="validator_data_type"></property>
+                                                    <property name="validator_style">wxFILTER_NONE</property>
+                                                    <property name="validator_type">wxDefaultValidator</property>
+                                                    <property name="validator_variable"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
                                                 </object>
                                             </object>
                                         </object>
@@ -8781,7 +8971,7 @@
                                 <property name="proportion">1</property>
                                 <object class="wxBoxSizer" expanded="1">
                                     <property name="minimum_size"></property>
-                                    <property name="name">bSizer502</property>
+                                    <property name="name">template_grid_sizer</property>
                                     <property name="orient">wxVERTICAL</property>
                                     <property name="permission">none</property>
                                     <object class="sizeritem" expanded="0">
@@ -8872,6 +9062,7 @@
                                             <property name="window_name"></property>
                                             <property name="window_style"></property>
                                             <event name="OnGridCellLeftDClick">OnTemplateGridDoubleLeftClick</event>
+                                            <event name="OnGridRangeSelect">OnTemplateGridRangeSelect</event>
                                         </object>
                                     </object>
                                 </object>

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -1085,154 +1085,190 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	m_mgr.AddPane( main_book, wxAuiPaneInfo() .Name( wxT("DataBook") ).Center() .Caption( wxT("Book") ).CaptionVisible( false ).CloseButton( false ).MaximizeButton( true ).MinimizeButton( true ).PinButton( true ).Dock().Resizable().FloatingSize( wxDefaultSize ).Row( 2 ).MinSize( wxSize( 500,500 ) ).Layer( 2 ).CentrePane() );
 
 	template_panel = new wxPanel( main_book, wxID_ANY, wxDefaultPosition, wxSize( -1,-1 ), wxTAB_TRAVERSAL );
-	wxBoxSizer* bSizer5612;
-	bSizer5612 = new wxBoxSizer( wxVERTICAL );
+	wxBoxSizer* template_sizer;
+	template_sizer = new wxBoxSizer( wxVERTICAL );
 
-	wxBoxSizer* bSizer102;
-	bSizer102 = new wxBoxSizer( wxHORIZONTAL );
+	wxBoxSizer* template_control_sizer;
+	template_control_sizer = new wxBoxSizer( wxHORIZONTAL );
 
-	wxBoxSizer* bSizer103;
-	bSizer103 = new wxBoxSizer( wxVERTICAL );
+	wxBoxSizer* template_control_left_sizer;
+	template_control_left_sizer = new wxBoxSizer( wxVERTICAL );
 
-	bSizer103->SetMinSize( wxSize( 612,-1 ) );
-	wxBoxSizer* bSizer126;
-	bSizer126 = new wxBoxSizer( wxHORIZONTAL );
-
-	label_choose_template = new wxStaticText( template_panel, wxID_ANY, wxT("Template:"), wxDefaultPosition, wxSize( 50,-1 ), 0 );
-	label_choose_template->Wrap( -1 );
-	bSizer126->Add( label_choose_template, 0, wxALIGN_CENTER|wxALL, 5 );
+	template_control_left_sizer->SetMinSize( wxSize( 500,-1 ) );
+	wxBoxSizer* template_template_control_sizer;
+	template_template_control_sizer = new wxBoxSizer( wxHORIZONTAL );
 
 	cmb_choose_template = new wxComboBox( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 );
-	cmb_choose_template->SetMinSize( wxSize( 195,-1 ) );
+	cmb_choose_template->SetToolTip( wxT("Use to select and load a template,\nOr to specify the name of a new template.") );
+	cmb_choose_template->SetMinSize( wxSize( 245,-1 ) );
 
-	bSizer126->Add( cmb_choose_template, 0, wxALIGN_CENTER|wxALL, 5 );
+	template_template_control_sizer->Add( cmb_choose_template, 0, wxALIGN_CENTER|wxALL, 5 );
 
-	btn_template_new = new wxButton( template_panel, wxID_ANY, wxT("New Template"), wxDefaultPosition, wxSize( 105,-1 ), 0 );
-	bSizer126->Add( btn_template_new, 0, wxALL, 5 );
+	btn_template_new = new wxButton( template_panel, wxID_ANY, wxT("New"), wxDefaultPosition, wxSize( -1,-1 ), 0 );
+	btn_template_new->SetToolTip( wxT("Create a new template with name from box on the left. ") );
 
-	btn_template_delete = new wxButton( template_panel, wxID_ANY, wxT("Delete Template"), wxDefaultPosition, wxSize( 105,-1 ), 0 );
-	bSizer126->Add( btn_template_delete, 0, wxALL, 5 );
+	template_template_control_sizer->Add( btn_template_new, 0, wxALL, 5 );
+
+	btn_template_delete = new wxButton( template_panel, wxID_ANY, wxT("Delete"), wxDefaultPosition, wxSize( -1,-1 ), 0 );
+	btn_template_delete->SetToolTip( wxT("Delete this template and it's content.") );
+
+	template_template_control_sizer->Add( btn_template_delete, 0, wxALL, 5 );
 
 
-	bSizer103->Add( bSizer126, 1, wxALIGN_LEFT, 5 );
+	template_control_left_sizer->Add( template_template_control_sizer, 1, wxALIGN_LEFT, 5 );
 
-	wxBoxSizer* bSizer1002;
-	bSizer1002 = new wxBoxSizer( wxHORIZONTAL );
+	wxBoxSizer* template_step_control_sizer;
+	template_step_control_sizer = new wxBoxSizer( wxHORIZONTAL );
+
+	btn_template_add_step = new wxButton( template_panel, wxID_ANY, wxT("Add"), wxDefaultPosition, wxDefaultSize, 0 );
+	btn_template_add_step->SetToolTip( wxT("Adds a step using the step detail panel to this template.") );
+
+	template_step_control_sizer->Add( btn_template_add_step, 0, wxALL, 5 );
 
 	btn_template_change_step = new wxButton( template_panel, wxID_ANY, wxT("Change"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer1002->Add( btn_template_change_step, 0, wxALL, 5 );
+	btn_template_change_step->SetToolTip( wxT("Update the select template step using inputs from the details panel.") );
+
+	template_step_control_sizer->Add( btn_template_change_step, 0, wxALL, 5 );
 
 	btn_template_delete_step = new wxButton( template_panel, wxID_ANY, wxT("Delete"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer1002->Add( btn_template_delete_step, 0, wxALL, 5 );
+	btn_template_delete_step->SetToolTip( wxT("Delete the selected template steps from this template.") );
 
-	btn_template_move_up_step = new wxButton( template_panel, wxID_ANY, wxT("Move Up"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer1002->Add( btn_template_move_up_step, 0, wxALL, 5 );
+	template_step_control_sizer->Add( btn_template_delete_step, 0, wxALL, 5 );
 
-	btn_template_move_down_step = new wxButton( template_panel, wxID_ANY, wxT("Move Down"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer1002->Add( btn_template_move_down_step, 0, wxALL, 5 );
+	btn_template_move_up_step = new wxButton( template_panel, wxID_ANY, wxT("Up"), wxDefaultPosition, wxDefaultSize, 0 );
+	btn_template_move_up_step->SetToolTip( wxT("Move this template step one row up.") );
+
+	template_step_control_sizer->Add( btn_template_move_up_step, 0, wxALL, 5 );
+
+	btn_template_move_down_step = new wxButton( template_panel, wxID_ANY, wxT("Down"), wxDefaultPosition, wxDefaultSize, 0 );
+	btn_template_move_down_step->SetToolTip( wxT("Move this template step one row down.") );
+
+	template_step_control_sizer->Add( btn_template_move_down_step, 0, wxALL, 5 );
 
 
-	bSizer103->Add( bSizer1002, 1, wxALIGN_LEFT, 5 );
+	template_control_left_sizer->Add( template_step_control_sizer, 1, wxALIGN_LEFT, 5 );
 
 
-	bSizer102->Add( bSizer103, 1, 0, 5 );
+	template_control_sizer->Add( template_control_left_sizer, 1, 0, 5 );
 
 	m_staticline51 = new wxStaticLine( template_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_VERTICAL );
-	bSizer102->Add( m_staticline51, 0, wxEXPAND | wxALL, 5 );
+	template_control_sizer->Add( m_staticline51, 0, wxALL|wxEXPAND, 5 );
 
-	wxBoxSizer* bSizer1041;
-	bSizer1041 = new wxBoxSizer( wxVERTICAL );
+	wxBoxSizer* template_import_export_sizer;
+	template_import_export_sizer = new wxBoxSizer( wxVERTICAL );
 
-	wxBoxSizer* bSizer1051;
-	bSizer1051 = new wxBoxSizer( wxHORIZONTAL );
+	btn_template_add_to_steps_list = new wxButton( template_panel, wxID_ANY, wxT("Import"), wxDefaultPosition, wxSize( -1,-1 ), 0 );
+	btn_template_add_to_steps_list->SetToolTip( wxT("Moves a range of steps from the steps panel into this template.") );
 
-	btn_template_add_to_steps_list = new wxButton( template_panel, wxID_ANY, wxT("Add to steps list"), wxDefaultPosition, wxSize( 125,-1 ), 0 );
-	bSizer1051->Add( btn_template_add_to_steps_list, 0, wxALL, 5 );
+	template_import_export_sizer->Add( btn_template_add_to_steps_list, 0, wxALL, 5 );
 
+	btn_template_add_from_steps_list = new wxButton( template_panel, wxID_ANY, wxT("Export"), wxDefaultPosition, wxSize( -1,-1 ), 0 );
+	btn_template_add_from_steps_list->SetToolTip( wxT("Moves the selected range of template steps or all template steps from this template into the steps page. Using the transformations on the right.") );
 
-	bSizer1041->Add( bSizer1051, 1, 0, 5 );
-
-	wxBoxSizer* bSizer1061;
-	bSizer1061 = new wxBoxSizer( wxHORIZONTAL );
-
-	btn_template_add_from_steps_list = new wxButton( template_panel, wxID_ANY, wxT("Add from steps list"), wxDefaultPosition, wxSize( 125,-1 ), 0 );
-	bSizer1061->Add( btn_template_add_from_steps_list, 0, wxALL, 5 );
+	template_import_export_sizer->Add( btn_template_add_from_steps_list, 0, wxALL, 5 );
 
 
-	bSizer1041->Add( bSizer1061, 1, 0, 5 );
+	template_control_sizer->Add( template_import_export_sizer, 0, wxEXPAND, 5 );
 
-
-	bSizer102->Add( bSizer1041, 0, wxEXPAND, 5 );
-
-	wxBoxSizer* bSizer1042;
-	bSizer1042 = new wxBoxSizer( wxVERTICAL );
+	wxBoxSizer* template_amount_sizer;
+	template_amount_sizer = new wxBoxSizer( wxVERTICAL );
 
 	wxBoxSizer* bSizer1052;
 	bSizer1052 = new wxBoxSizer( wxHORIZONTAL );
 
-	label_template_amount_offset = new wxStaticText( template_panel, wxID_ANY, wxT("Amount-Offset:"), wxDefaultPosition, wxSize( 85,-1 ), 0 );
+	label_template_amount_offset = new wxStaticText( template_panel, wxID_ANY, wxT("Offset:"), wxDefaultPosition, wxSize( 55,-1 ), 0 );
 	label_template_amount_offset->Wrap( -1 );
 	bSizer1052->Add( label_template_amount_offset, 0, wxALIGN_CENTER, 5 );
 
-	spin_amount_offset = new wxSpinCtrl( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), wxSP_ARROW_KEYS, -10000, 10000, 0 );
+	spin_amount_offset = new wxSpinCtrl( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), wxALIGN_RIGHT|wxSP_ARROW_KEYS, -10000, 10000, 0 );
+	spin_amount_offset->SetToolTip( wxT("Used to specify an amount off-set to the whole range of exported steps.\nThis is applied after multiplication.") );
+
 	bSizer1052->Add( spin_amount_offset, 0, wxALL, 5 );
 
 
-	bSizer1042->Add( bSizer1052, 1, 0, 5 );
+	template_amount_sizer->Add( bSizer1052, 1, 0, 5 );
 
 	wxBoxSizer* bSizer1062;
 	bSizer1062 = new wxBoxSizer( wxHORIZONTAL );
 
-	label_template_amount_multiplier = new wxStaticText( template_panel, wxID_ANY, wxT("Amount-Multi:"), wxDefaultPosition, wxSize( 85,-1 ), 0 );
+	label_template_amount_multiplier = new wxStaticText( template_panel, wxID_ANY, wxT("Multiplier:"), wxDefaultPosition, wxSize( 55,-1 ), 0 );
 	label_template_amount_multiplier->Wrap( -1 );
 	bSizer1062->Add( label_template_amount_multiplier, 0, wxALIGN_CENTER, 5 );
 
-	spin_amount_multiplier = new wxSpinCtrl( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), wxSP_ARROW_KEYS, -10000, 10000, 0 );
+	spin_amount_multiplier = new wxSpinCtrl( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), wxALIGN_RIGHT|wxSP_ARROW_KEYS, 0, 100, 1 );
+	spin_amount_multiplier->SetToolTip( wxT("Used to specify an amount multiplication to the whole range of exported steps.\nThis is applied before offset.") );
+
 	bSizer1062->Add( spin_amount_multiplier, 0, wxALL, 5 );
 
 
-	bSizer1042->Add( bSizer1062, 1, 0, 5 );
+	template_amount_sizer->Add( bSizer1062, 1, 0, 5 );
 
 
-	bSizer102->Add( bSizer1042, 0, 0, 5 );
+	template_control_sizer->Add( template_amount_sizer, 0, 0, 5 );
 
-	wxBoxSizer* bSizer104;
-	bSizer104 = new wxBoxSizer( wxVERTICAL );
+	m_staticline2 = new wxStaticLine( template_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_VERTICAL );
+	template_control_sizer->Add( m_staticline2, 0, wxEXPAND | wxALL, 5 );
+
+	wxBoxSizer* template_coordinate_sizer;
+	template_coordinate_sizer = new wxBoxSizer( wxVERTICAL );
 
 	wxBoxSizer* bSizer105;
 	bSizer105 = new wxBoxSizer( wxHORIZONTAL );
 
-	label_template_x_offset = new wxStaticText( template_panel, wxID_ANY, wxT("X-Offset:"), wxDefaultPosition, wxSize( 50,-1 ), 0 );
+	label_template_x_offset = new wxStaticText( template_panel, wxID_ANY, wxT("X:"), wxDefaultPosition, wxSize( 15,-1 ), 0 );
 	label_template_x_offset->Wrap( -1 );
 	bSizer105->Add( label_template_x_offset, 0, wxALIGN_CENTER, 5 );
 
-	spin_x_offset = new wxSpinCtrl( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), wxSP_ARROW_KEYS, -10000, 10000, 0 );
+	spin_x_offset = new wxSpinCtrl( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 65,-1 ), wxALIGN_RIGHT|wxSP_ARROW_KEYS, -1000000, 1000000, 0 );
+	spin_x_offset->SetToolTip( wxT("X coordinate offset") );
+
 	bSizer105->Add( spin_x_offset, 0, wxALL, 5 );
 
 
-	bSizer104->Add( bSizer105, 1, 0, 5 );
+	template_coordinate_sizer->Add( bSizer105, 1, 0, 5 );
 
 	wxBoxSizer* bSizer106;
 	bSizer106 = new wxBoxSizer( wxHORIZONTAL );
 
-	label_template_y_offset = new wxStaticText( template_panel, wxID_ANY, wxT("Y-Offset:"), wxDefaultPosition, wxSize( 50,-1 ), 0 );
+	label_template_y_offset = new wxStaticText( template_panel, wxID_ANY, wxT("Y:"), wxDefaultPosition, wxSize( 15,-1 ), 0 );
 	label_template_y_offset->Wrap( -1 );
 	bSizer106->Add( label_template_y_offset, 0, wxALIGN_CENTER, 5 );
 
-	spin_y_offset = new wxSpinCtrl( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 50,-1 ), wxSP_ARROW_KEYS, -10000, 10000, 0 );
+	spin_y_offset = new wxSpinCtrl( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 65,-1 ), wxALIGN_RIGHT|wxSP_ARROW_KEYS, -1000000, 1000000, 0 );
+	spin_y_offset->SetToolTip( wxT("Y coordinate offset") );
+
 	bSizer106->Add( spin_y_offset, 0, wxALL, 5 );
 
 
-	bSizer104->Add( bSizer106, 1, 0, 5 );
+	template_coordinate_sizer->Add( bSizer106, 1, 0, 5 );
 
 
-	bSizer102->Add( bSizer104, 0, 0, 5 );
+	template_control_sizer->Add( template_coordinate_sizer, 0, 0, 5 );
+
+	wxBoxSizer* template_advanced_sizer;
+	template_advanced_sizer = new wxBoxSizer( wxVERTICAL );
+
+	spin_template_iterator = new wxSpinCtrl( template_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 68,-1 ), wxSP_ARROW_KEYS, 0, 99, 0 );
+	spin_template_iterator->SetToolTip( wxT("Coordinate offset multiplier (X,Y) when using Export.\nCalculated: (X,Y) + offset * multiplier\n\nThis will auto increment when using Export.\nSet to 0 to not increment this will be interpreted as a multiplier of 1.") );
+
+	template_advanced_sizer->Add( spin_template_iterator, 0, wxBOTTOM|wxLEFT|wxTOP, 5 );
+
+	wxString choice_template_directionChoices[] = { wxT("Normal"), wxT("Left"), wxT("Reverse"), wxT("Right") };
+	int choice_template_directionNChoices = sizeof( choice_template_directionChoices ) / sizeof( wxString );
+	choice_template_direction = new wxChoice( template_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, choice_template_directionNChoices, choice_template_directionChoices, 0 );
+	choice_template_direction->SetSelection( 0 );
+	choice_template_direction->SetToolTip( wxT("Rotational transformation for Export.\nEach rotation transform the export template 90 degrees from the normal axis.\n\nCalculated: ( (X,Y) + offset * multiplier ) * v90degree") );
+
+	template_advanced_sizer->Add( choice_template_direction, 0, wxBOTTOM|wxLEFT|wxTOP, 5 );
 
 
-	bSizer5612->Add( bSizer102, 1, wxEXPAND, 5 );
+	template_control_sizer->Add( template_advanced_sizer, 1, 0, 5 );
 
-	wxBoxSizer* bSizer502;
-	bSizer502 = new wxBoxSizer( wxVERTICAL );
+
+	template_sizer->Add( template_control_sizer, 1, wxEXPAND, 5 );
+
+	wxBoxSizer* template_grid_sizer;
+	template_grid_sizer = new wxBoxSizer( wxVERTICAL );
 
 	grid_template = new wxGrid( template_panel, wxID_ANY, wxDefaultPosition, wxSize( -1,-1 ), 0 );
 
@@ -1281,15 +1317,15 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	grid_template->SetDefaultCellAlignment( wxALIGN_LEFT, wxALIGN_TOP );
 	grid_template->SetMinSize( wxSize( 860,2500 ) );
 
-	bSizer502->Add( grid_template, 0, wxALL|wxEXPAND, 5 );
+	template_grid_sizer->Add( grid_template, 0, wxALL|wxEXPAND, 5 );
 
 
-	bSizer5612->Add( bSizer502, 1, wxEXPAND, 5 );
+	template_sizer->Add( template_grid_sizer, 1, wxEXPAND, 5 );
 
 
-	template_panel->SetSizer( bSizer5612 );
+	template_panel->SetSizer( template_sizer );
 	template_panel->Layout();
-	bSizer5612->Fit( template_panel );
+	template_sizer->Fit( template_panel );
 	main_book->AddPage( template_panel, wxT("Templates"), false, wxNullBitmap );
 	step_panel = new wxPanel( main_book, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
 	wxBoxSizer* step_panel_sizer;
@@ -1631,6 +1667,8 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	cmb_choose_template->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( GUI_Base::OnTemplateText ), NULL, this );
 	btn_template_new->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnNewTemplateClicked ), NULL, this );
 	btn_template_delete->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnDeleteTemplateClicked ), NULL, this );
+	btn_template_delete->Connect( wxEVT_RIGHT_UP, wxMouseEventHandler( GUI_Base::OnDeleteTemplateRightClicked ), NULL, this );
+	btn_template_add_step->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateAddStepClicked ), NULL, this );
 	btn_template_change_step->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateChangeStepClicked ), NULL, this );
 	btn_template_delete_step->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateDeleteStepClicked ), NULL, this );
 	btn_template_move_up_step->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateMoveUpClicked ), NULL, this );
@@ -1638,6 +1676,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	btn_template_add_to_steps_list->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateAddToStepsListClicked ), NULL, this );
 	btn_template_add_from_steps_list->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateAddFromStepsListClicked ), NULL, this );
 	grid_template->Connect( wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler( GUI_Base::OnTemplateGridDoubleLeftClick ), NULL, this );
+	grid_template->Connect( wxEVT_GRID_RANGE_SELECT, wxGridRangeSelectEventHandler( GUI_Base::OnTemplateGridRangeSelect ), NULL, this );
 	step_search_ctrl->Connect( wxEVT_COMMAND_SEARCHCTRL_CANCEL_BTN, wxCommandEventHandler( GUI_Base::StepSeachOnCancelButton ), NULL, this );
 	step_search_ctrl->Connect( wxEVT_COMMAND_SEARCHCTRL_SEARCH_BTN, wxCommandEventHandler( GUI_Base::StepSeachOnSearchButton ), NULL, this );
 	step_search_ctrl->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( GUI_Base::StepSeachOnText ), NULL, this );
@@ -1719,6 +1758,8 @@ GUI_Base::~GUI_Base()
 	cmb_choose_template->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( GUI_Base::OnTemplateText ), NULL, this );
 	btn_template_new->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnNewTemplateClicked ), NULL, this );
 	btn_template_delete->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnDeleteTemplateClicked ), NULL, this );
+	btn_template_delete->Disconnect( wxEVT_RIGHT_UP, wxMouseEventHandler( GUI_Base::OnDeleteTemplateRightClicked ), NULL, this );
+	btn_template_add_step->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateAddStepClicked ), NULL, this );
 	btn_template_change_step->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateChangeStepClicked ), NULL, this );
 	btn_template_delete_step->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateDeleteStepClicked ), NULL, this );
 	btn_template_move_up_step->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateMoveUpClicked ), NULL, this );
@@ -1726,6 +1767,7 @@ GUI_Base::~GUI_Base()
 	btn_template_add_to_steps_list->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateAddToStepsListClicked ), NULL, this );
 	btn_template_add_from_steps_list->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnTemplateAddFromStepsListClicked ), NULL, this );
 	grid_template->Disconnect( wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler( GUI_Base::OnTemplateGridDoubleLeftClick ), NULL, this );
+	grid_template->Disconnect( wxEVT_GRID_RANGE_SELECT, wxGridRangeSelectEventHandler( GUI_Base::OnTemplateGridRangeSelect ), NULL, this );
 	step_search_ctrl->Disconnect( wxEVT_COMMAND_SEARCHCTRL_CANCEL_BTN, wxCommandEventHandler( GUI_Base::StepSeachOnCancelButton ), NULL, this );
 	step_search_ctrl->Disconnect( wxEVT_COMMAND_SEARCHCTRL_SEARCH_BTN, wxCommandEventHandler( GUI_Base::StepSeachOnSearchButton ), NULL, this );
 	step_search_ctrl->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( GUI_Base::StepSeachOnText ), NULL, this );

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -31,6 +31,7 @@
 #include <wx/checkbox.h>
 #include <wx/button.h>
 #include <wx/statline.h>
+#include <wx/choice.h>
 #include <wx/grid.h>
 #include <wx/srchctrl.h>
 #include <wx/clrpicker.h>
@@ -157,10 +158,10 @@ class GUI_Base : public wxFrame
 		wxButton* walk_panel_button_downright;
 		wxAuiNotebook* main_book;
 		wxPanel* template_panel;
-		wxStaticText* label_choose_template;
 		wxComboBox* cmb_choose_template;
 		wxButton* btn_template_new;
 		wxButton* btn_template_delete;
+		wxButton* btn_template_add_step;
 		wxButton* btn_template_change_step;
 		wxButton* btn_template_delete_step;
 		wxButton* btn_template_move_up_step;
@@ -172,10 +173,13 @@ class GUI_Base : public wxFrame
 		wxSpinCtrl* spin_amount_offset;
 		wxStaticText* label_template_amount_multiplier;
 		wxSpinCtrl* spin_amount_multiplier;
+		wxStaticLine* m_staticline2;
 		wxStaticText* label_template_x_offset;
 		wxSpinCtrl* spin_x_offset;
 		wxStaticText* label_template_y_offset;
 		wxSpinCtrl* spin_y_offset;
+		wxSpinCtrl* spin_template_iterator;
+		wxChoice* choice_template_direction;
 		wxGrid* grid_template;
 		wxPanel* step_panel;
 		wxSearchCtrl* step_search_ctrl;
@@ -306,6 +310,8 @@ class GUI_Base : public wxFrame
 		virtual void OnTemplateText( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnNewTemplateClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnDeleteTemplateClicked( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnDeleteTemplateRightClicked( wxMouseEvent& event ) { event.Skip(); }
+		virtual void OnTemplateAddStepClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnTemplateChangeStepClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnTemplateDeleteStepClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnTemplateMoveUpClicked( wxCommandEvent& event ) { event.Skip(); }
@@ -313,6 +319,7 @@ class GUI_Base : public wxFrame
 		virtual void OnTemplateAddToStepsListClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnTemplateAddFromStepsListClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnTemplateGridDoubleLeftClick( wxGridEvent& event ) { event.Skip(); }
+		virtual void OnTemplateGridRangeSelect( wxGridRangeSelectEvent& event ) { event.Skip(); }
 		virtual void StepSeachOnCancelButton( wxCommandEvent& event ) { event.Skip(); }
 		virtual void StepSeachOnSearchButton( wxCommandEvent& event ) { event.Skip(); }
 		virtual void StepSeachOnText( wxCommandEvent& event ) { event.Skip(); }

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -334,7 +334,7 @@ void cMain::OnImportStepsIntoTemplateCtrlEnter(wxCommandEvent& event)
 	auto a = template_map.insert(std::pair<std::string, std::vector<StepParameters>>(name, step_parameters) );
 	for (int i = 0; i < step_parameters.size(); i++) template_map[name].push_back(step_parameters[i]);
 
-	UpdateTemplateGrid(grid_template, template_map[name]);
+	UpdateTemplateGrid(template_map[name]);
 
 	if (import_steps_clear_checkbox->IsChecked()) import_steps_text_import->Clear();
 

--- a/src/TemplatePage.cpp
+++ b/src/TemplatePage.cpp
@@ -1,0 +1,431 @@
+﻿#include "cMain.h"
+
+void cMain::TemplatePageStartup()
+{
+	btn_template_add_to_steps_list->SetLabel(L"Export ⭲");
+	btn_template_add_from_steps_list->SetLabel(L"Import ⭰");
+}
+
+#pragma region TemplateControl
+void cMain::ClearTemplateGrid(bool disable)
+{
+	if (grid_template->GetNumberRows() > 0)
+		grid_template->DeleteRows(0, grid_template->GetNumberRows());
+
+	if (disable)
+	{
+		auto e = wxGridRangeSelectEvent();
+		OnTemplateGridRangeSelect(e);
+	}
+
+	spin_template_iterator->SetValue(0);
+	choice_template_direction->SetSelection(0);
+}
+
+void cMain::UpdateTemplateGrid(vector<StepParameters>& steps)
+{
+	ClearTemplateGrid(false);
+	grid_template->InsertRows(0, steps.size());
+	for (int i = 0; i < steps.size(); i++)
+	{
+		GridEntry gridEntry = PrepareStepParametersForGrid(&steps[i]);
+		PopulateGrid(grid_template, i, &gridEntry);
+		BackgroundColorUpdate(grid_template, i, steps[i].StepEnum);
+	}
+}
+
+void cMain::OnTemplateChosen(wxCommandEvent& event)
+{
+	UpdateTemplateGrid(template_map[cmb_choose_template->GetValue().ToStdString()]);
+}
+
+void cMain::OnTemplateText(wxCommandEvent& event)
+{
+	auto name = cmb_choose_template->GetValue().ToStdString();
+	auto list = template_map.find(name);
+	if (list == template_map.end())
+	{
+		ClearTemplateGrid();
+		btn_template_new->Enable(!name.empty());
+		btn_template_delete->Disable();
+		btn_template_add_from_steps_list->Disable();
+		btn_template_add_step->Disable();
+	}
+	else
+	{
+		UpdateTemplateGrid(list->second);
+		btn_template_new->Disable();
+		btn_template_delete->Enable();
+		btn_template_add_from_steps_list->Enable();
+		btn_template_add_step->Enable();
+	}
+}
+
+void cMain::OnNewTemplateClicked(wxCommandEvent& event)
+{
+	int rowCount = cmb_choose_template->GetCount();
+	string name = cmb_choose_template->GetValue().ToStdString();
+
+	if (name == "")
+	{
+		wxMessageBox("Please write a template name", "Template name cannot be blank");
+		cmb_choose_template->SetFocus();
+		return;
+	}
+
+	auto find_template = template_map.find(cmb_choose_template->GetValue().ToStdString());
+	if (find_template != template_map.end())
+	{
+		wxMessageBox("Template names have to be unique - please write a new name in the Choose Template field", "Template names should be unique");
+		cmb_choose_template->SetFocus();
+		return;
+	}
+
+	template_choices.Add(name);
+	template_choices.Sort();
+
+	cmb_choose_template->Clear();
+	cmb_choose_template->Append(template_choices);
+	cmb_choose_template->SetValue(name);
+	cmb_choose_template->AutoComplete(template_choices);
+
+	vector<StepParameters> template_list = {};
+	UpdateTemplateGrid(template_list);
+	template_map.insert(pair<string, vector<StepParameters>>(name, template_list));
+
+	btn_template_add_from_steps_list->Enable();
+	btn_template_add_step->Enable();
+
+	no_changes = false;
+}
+
+void cMain::OnDeleteTemplate(bool force)
+{
+	auto name = cmb_choose_template->GetValue().ToStdString();
+
+	if (template_map.find(name) == template_map.end())
+	{
+		return;
+	}
+	else if (!force && wxMessageBox("Are you sure you want to delete this template?", "Delete template", wxICON_QUESTION | wxYES_NO, this) != wxYES)
+	{
+		return;
+	}
+
+	template_map.erase(name);
+	template_choices.Remove(name);
+
+	cmb_choose_template->Clear();
+	cmb_choose_template->Append(template_choices);
+	cmb_choose_template->AutoComplete(template_choices);
+
+	if (template_choices.size())
+	{
+		cmb_choose_template->SetValue(*template_choices.begin());
+		auto e = wxCommandEvent{};
+		OnTemplateChosen(e);
+	}
+	else
+	{
+		ClearTemplateGrid();
+	}
+
+	no_changes = false;
+}
+void cMain::OnDeleteTemplateRightClicked(wxMouseEvent& event)
+{
+	OnDeleteTemplate(true);
+}
+void cMain::OnDeleteTemplateClicked(wxCommandEvent& event)
+{
+	OnDeleteTemplate(false);
+}
+#pragma endregion TemplateControl
+
+#pragma region StepControl
+void cMain::OnTemplateAddStepClicked(wxCommandEvent& event)
+{
+	auto stepParameters = ExtractStepParameters();
+	const int row = grid_template->IsSelection() ? *grid_template->GetSelectedRows().begin() : grid_template->GetNumberRows();
+	
+	grid_template->InsertRows(row);
+	GridEntry gridEntry = PrepareStepParametersForGrid(&stepParameters);
+	PopulateGrid(grid_template, row, &gridEntry);
+	BackgroundColorUpdate(grid_template, row, stepParameters.StepEnum);
+
+	vector<StepParameters> list = template_map.find(cmb_choose_template->GetValue().ToStdString())->second;
+	list.insert(list.begin() + row, stepParameters);
+
+	no_changes = false;
+}
+
+void cMain::OnTemplateChangeStepClicked(wxCommandEvent& event)
+{
+	auto stepParameters = ExtractStepParameters();
+	auto name = cmb_choose_template->GetValue().ToStdString();
+	if (template_map.find(name) == template_map.end())
+	{
+		return;
+	}
+
+	if (!ChangeRow(grid_template, stepParameters))
+	{
+		return;
+	}
+
+	auto rowNum = *grid_template->GetSelectedRows().begin();
+
+	template_map[name][rowNum] = stepParameters;
+}
+
+void cMain::OnTemplateDeleteStepClicked(wxCommandEvent& event)
+{
+	if (wxMessageBox("Are you sure you want to delete this template step?", "Delete template step", wxICON_QUESTION | wxYES_NO, this) != wxYES)
+	{
+		return;
+	}
+
+	DeleteRow(grid_template, cmb_choose_template, template_map);
+}
+
+void cMain::TemplateMoveRow(wxGrid* grid, wxComboBox* cmb, bool up, map<string, vector<StepParameters>>& map)
+{
+	if (!grid->IsSelection() || !grid->GetSelectedRows().begin())
+	{
+		wxMessageBox("Please select row(s) to move", "Select row(s)");
+	}
+
+	for (const auto& block : grid->GetSelectedRowBlocks())
+	{
+		auto rowNum = block.GetTopRow();
+		auto rowCount = block.GetBottomRow() - rowNum + 1;
+
+		auto row = 0;
+		if (up)
+		{
+			if (rowNum == 0)
+			{
+				continue;
+			}
+
+			row = rowNum - 1;
+
+		}
+		else
+		{
+			if ((rowNum + rowCount) == (grid->GetNumberRows()))
+			{
+				continue;
+			}
+
+			row = rowNum + rowCount + 1;
+			rowCount = 0;
+		}
+
+		grid->InsertRows(rowNum + rowCount);
+
+		GridTransfer(grid, row, grid, rowNum + rowCount);
+
+		BackgroundColorUpdate(grid, rowNum + rowCount, ToStepType(grid->GetCellValue(rowNum + rowCount, 0).ToStdString()));
+
+		grid->DeleteRows(row);
+
+		if (!map.empty())
+		{
+			std::string map_name = cmb->GetValue().ToStdString();
+			if (map.find(map_name) != map.end())
+			{
+				if (up)
+				{
+
+					auto it1 = map[map_name].begin();
+					it1 += row;
+
+					auto data = *it1;
+					map[map_name].erase(it1);
+
+					auto it2 = map[map_name].begin();
+					it2 += rowNum + rowCount - 1;
+					map[map_name].insert(it2, data);
+				}
+				else
+				{
+					auto it1 = map[map_name].begin();
+					it1 += row - 1;
+
+					auto it2 = map[map_name].begin();
+					it2 += rowNum;
+
+					auto data = *it1;
+					map[map_name].erase(it1, it1 + 1);
+					map[map_name].insert(it2, data);
+				}
+			}
+		}
+	}
+
+	no_changes = false;
+}
+
+void cMain::OnTemplateMoveUpClicked(wxCommandEvent& event)
+{
+	TemplateMoveRow(grid_template, cmb_choose_template, true, template_map);
+}
+
+void cMain::OnTemplateMoveDownClicked(wxCommandEvent& event)
+{
+	TemplateMoveRow(grid_template, cmb_choose_template, false, template_map);
+}
+#pragma endregion StepControl
+
+#pragma region othercontrol
+void cMain::OnTemplateAddFromStepsListClicked(wxCommandEvent& event)
+{
+	UpdateMapWithNewSteps(grid_template, cmb_choose_template, template_map);
+}
+
+void cMain::OnTemplateAddToStepsListClicked(wxCommandEvent& event)
+{
+	if (spin_amount_offset->GetValue() != 0 && spin_amount_multiplier->GetValue() != 0)
+	{
+		//wxMessageBox("Please either use units-offset or units-multiplier", "Invalid use of template attributes");
+		//return;
+	}
+
+	int moveTo = grid_steps->GetNumberRows();
+
+	if (grid_steps->IsSelection())
+	{
+		if (!grid_steps->GetSelectedRows().begin())
+		{
+			wxMessageBox("Please either select row(s) or nothing", "Step list selection not valid");
+			return;
+		}
+
+		moveTo = *grid_steps->GetSelectedRows().begin();
+	}
+
+	auto list = template_map[cmb_choose_template->GetValue().ToStdString()]; 
+	auto rows_ = grid_template->GetSelectedRows();
+	if (rows_.IsEmpty()) 
+		for (int i = 0; i < grid_template->GetNumberRows(); i++) 
+			rows_.Add(i);
+
+	const int dir = choice_template_direction->GetSelection();
+	int iterator = spin_template_iterator->GetValue();
+	if (iterator == 0) 
+		iterator = 1;
+	else 
+		spin_template_iterator->SetValue(iterator + 1);
+
+	const int x_off = spin_x_offset->GetValue() * iterator,
+		y_off = spin_y_offset->GetValue() * iterator;
+	const int amount_off = spin_amount_offset->GetValue(),
+		amount_multiplier = spin_amount_multiplier->GetValue();
+
+	for (const auto row : rows_)
+	{
+		StepParameters step = list[row];
+
+		TemplateAlterStep(step, dir, x_off, y_off, amount_off, amount_multiplier);
+
+		UpdateStepGrid(moveTo++, &step);
+	}
+
+	no_changes = false;
+}
+
+enum template_direction_choice
+{
+	Normal = 0,
+	Left = 1,
+	Reverse = 2,
+	Right = 3,
+};
+pair<double, double> transform(double x, double y, template_direction_choice dir)
+{
+	switch (dir)
+	{
+		case Normal: return {x, y};
+		case Left: return {y, -x};
+		case Reverse: return {-x, -y};
+		case Right: return {-y, x};
+		
+		default: return {x, y};
+	}
+}
+Orientation tranform(Orientation o, template_direction_choice dir)
+{
+	switch (dir)
+	{
+		case Normal: return o;
+		case Left: return (Orientation)(o + 3 % 4);
+		case Reverse: return (Orientation)(o + 2 % 4);
+		case Right: return (Orientation)(o + 1 % 4);
+
+		default: return o;
+	}
+}
+
+void cMain::TemplateAlterStep(StepParameters& step, const int direction, int x_off, int y_off, int amount_off, int amount_multi)
+{
+	if (step.Amount != "" && step.Amount != "All")
+	{
+		step.Amount = to_string(
+			stoi(step.Amount)
+			* amount_multi
+			+ amount_off
+		);
+	}
+	auto orientation = MapStringToOrientation.find(step.Orientation);
+	auto build_direction = MapStringToOrientation.find(step.Direction);
+	if (orientation != MapStringToOrientation.end())
+		step.Orientation = orientation_list[tranform(orientation->second, (template_direction_choice)direction)];
+	if (build_direction != MapStringToOrientation.end())
+		step.Direction = orientation_list[tranform(build_direction->second, (template_direction_choice)direction)];
+
+	if (step.X == invalidX) return;
+	
+	auto [x,y] = transform(step.X + x_off, step.Y + y_off, (template_direction_choice)direction);
+	step.X = step.OriginalX = x;
+	step.Y = step.OriginalY = y;
+}
+#pragma endregion othercontrol
+
+#pragma region grid
+void cMain::OnTemplateGridDoubleLeftClick(wxGridEvent& event)
+{
+	auto gridEntry = ExtractGridEntry(grid_template, event.GetRow());
+
+	UpdateParameters(&gridEntry, event);
+}
+
+void cMain::OnTemplateGridRangeSelect(wxGridRangeSelectEvent& event)
+{
+	auto rows = grid_template->GetSelectedRows();
+	if (rows.size() < 1)
+	{
+		btn_template_change_step->Disable();
+		btn_template_delete_step->Disable();
+		btn_template_move_down_step->Disable();
+		btn_template_move_up_step->Disable();
+		btn_template_add_to_steps_list->Enable(grid_template->GetNumberRows() > 0);
+	}
+	else if (rows.size() == 1)
+	{
+		btn_template_change_step->Enable();
+		btn_template_delete_step->Enable();
+		btn_template_move_down_step->Enable();
+		btn_template_move_up_step->Enable();
+		btn_template_add_to_steps_list->Enable();
+	}
+	else
+	{
+		btn_template_change_step->Disable();
+		btn_template_delete_step->Enable();
+		btn_template_move_down_step->Enable();
+		btn_template_move_up_step->Enable();
+		btn_template_add_to_steps_list->Enable();
+	}
+}
+#pragma endregion grid

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -200,19 +200,23 @@ protected:
 	// Template
 	void OnNewTemplateClicked(wxCommandEvent& event);
 	void OnDeleteTemplateClicked(wxCommandEvent& event);
+	void OnDeleteTemplateRightClicked(wxMouseEvent& event);
+	void OnDeleteTemplate(bool force);
 	void OnTemplateAddFromStepsListClicked(wxCommandEvent& event);
 	void OnTemplateAddToStepsListClicked(wxCommandEvent& event);
+	void OnTemplateAddStepClicked(wxCommandEvent& event);
 	void OnTemplateChangeStepClicked(wxCommandEvent& event);
 	void OnTemplateDeleteStepClicked(wxCommandEvent& event);
 	void OnTemplateMoveUpClicked(wxCommandEvent& event);
 	void OnTemplateMoveDownClicked(wxCommandEvent& event);
 
 	void OnTemplateGridDoubleLeftClick(wxGridEvent& event);
+	void OnTemplateGridRangeSelect(wxGridRangeSelectEvent& event);
 
 	void OnTemplateChosen(wxCommandEvent& event);
 	void OnTemplateText(wxCommandEvent& event);
 
-	void TemplateAlterStep(StepParameters& step);
+	void TemplateAlterStep(StepParameters& step, const int direction, int x_off, int y_off, int amount_off, int amount_multi);
 
 	//Seach
 	void StepSeachOnText(wxCommandEvent& event);
@@ -290,7 +294,9 @@ private:
 	void BackgroundColorUpdate(wxGrid* grid, int row, StepType step);
 
 	void UpdateMapWithNewSteps(wxGrid* grid, wxComboBox* cmb, map<string, vector<StepParameters>>& map);
-	void UpdateTemplateGrid(wxGrid* grid, vector<StepParameters>& steps);
+	void UpdateTemplateGrid(vector<StepParameters>& steps);
+	void ClearTemplateGrid(bool disable = true);
+	void TemplatePageStartup();
 
 	void setup_paramters(const int parameters);
 	void SetupModifiers(StepType type);


### PR DESCRIPTION
### Overhaul
This mixes a gui overhaul of the template page, a refactor of code related to templates and adds some new features for templates.

### Changes
Moved most Template stuff from cMain.cpp to a new file called TemplatePage. Refactored most Template functions to follow.

Renamed box sizer in template page-
Changed labels of Template page control buttons-
Added Tooltips to Template page control buttons.
Added Unicode arrows to Import&Export buttons.
Added add step button to template page.

Added Template iterator transformation.
Added Template direction transformation.
Changed amount transformation to allow both types at the same time.

Added button toggles.

![image](https://github.com/MortenTobiasNielsen/Factorio-TAS-Generator/assets/18309265/286a63c1-0159-4cd1-83d0-6feb9302a100)
