### PR TITLE
Fixed crash in focus mode and fixed rotate not having the correct building

### DIFF
--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -211,8 +211,13 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				}
 
 				SetBuildingAndOrientation(&steps[i]);
+				if (building == "N/A")
+				{
+					UnexpectedError(dialog_progress_bar, i);
+					return;
+				}
 
-				row_rotate(currentStep, x_cord, y_cord, amount, item, build_orientation, direction_to_build, amount_of_buildings, building_size, comment);
+				row_rotate(currentStep, x_cord, y_cord, amount, building, build_orientation, direction_to_build, amount_of_buildings, building_size, comment);
 				break;
 
 			case e_craft:
@@ -953,7 +958,6 @@ void GenerateScript::_throw(string step, string x_cord, string y_cord, string it
 
 void GenerateScript::rotate(string step, string action, string x_cord, string y_cord, string times, string item, string OrientationEnum, string comment)
 {
-
 	check_interact_distance(step, action, x_cord, y_cord, item, OrientationEnum);
 
 	if (std::stoi(times) == 3)

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -158,9 +158,11 @@ void cMain::OnStepsFocusCheckbox(wxCommandEvent& event)
 	steps_focus_checkbox->Disable();
 	{
 		HandleFocusMode(event.IsChecked(), true);
-
-		grid_steps->GoToCell(row_count - 1, 0);
-		grid_steps->GoToCell(first_row_index - (first_row_index > 4 ? 3 : 0), 0); // move the grid to first selected row
+		if (first_row_index != -1)
+		{
+			grid_steps->GoToCell(row_count - 1, 0);
+			grid_steps->GoToCell(first_row_index - (first_row_index > 4 ? 3 : 0), 0); // move the grid to first selected row
+		}
 	}
 	steps_focus_checkbox->Enable();
 }


### PR DESCRIPTION
- Fixed a crash when toggling on focus mode without any rows in the grid.
- Changed rotate to use the found building instead of item, fixing a problem with having invalid data in the item field.