### PR TITLE
Refactor stepparameters

### DIFF
--- a/src/Factorio-TAS-Generator.vcxproj
+++ b/src/Factorio-TAS-Generator.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="GUI_Base.cpp" />
     <ClCompile Include="ImportStepsPanel.cpp" />
     <ClCompile Include="Shared functions\Functions.cpp" />
+    <ClCompile Include="Shared functions\StringFunctions.cpp" />
     <ClCompile Include="ShortcutChanger.cpp" />
     <ClCompile Include="SearchUtil.cpp" />
     <ClCompile Include="SteptypeColour.cpp" />
@@ -197,6 +198,7 @@
     <ClInclude Include="nlohmann\json.hpp" />
     <ClInclude Include="SearchUtil.h" />
     <ClInclude Include="Shared functions\Functions.h" />
+    <ClInclude Include="Shared functions\StringFunctions.h" />
     <ClInclude Include="ShortcutChanger.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="DialogProgressBar.h" />

--- a/src/Factorio-TAS-Generator.vcxproj.filters
+++ b/src/Factorio-TAS-Generator.vcxproj.filters
@@ -3,21 +3,9 @@
   <ItemGroup>
     <ClCompile Include="cApp.cpp" />
     <ClCompile Include="cMain.cpp" />
-    <ClCompile Include="Functions.cpp" />
     <ClCompile Include="GenerateScript.cpp" />
     <ClCompile Include="GUI_Base.cpp" />
-    <ClCompile Include="OpenTas.cpp" />
-    <ClCompile Include="SaveTas.cpp" />
     <ClCompile Include="TypePanel.cpp" />
-    <ClCompile Include="BuildingNameToIndex.cpp">
-      <Filter>Maps</Filter>
-    </ClCompile>
-    <ClCompile Include="StepParameters.cpp">
-      <Filter>Structs</Filter>
-    </ClCompile>
-    <ClCompile Include="StepNameToEnum.cpp">
-      <Filter>Maps</Filter>
-    </ClCompile>
     <ClCompile Include="DialogProgressBar.cpp" />
     <ClCompile Include="SearchUtil.cpp">
       <Filter>Structs</Filter>
@@ -26,39 +14,26 @@
     <ClCompile Include="ImportStepsPanel.cpp" />
     <ClCompile Include="CommandStack.cpp" />
     <ClCompile Include="SteptypeColour.cpp" />
+    <ClCompile Include="Shared functions\Functions.cpp" />
+    <ClCompile Include="Structures\StepParameters.cpp" />
+    <ClCompile Include="TAS save file\OpenTas.cpp" />
+    <ClCompile Include="TAS save file\SaveTas.cpp" />
+    <ClCompile Include="TemplatePage.cpp" />
+    <ClCompile Include="WalkPanel.cpp" />
+    <ClCompile Include="Shared functions\StringFunctions.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cApp.h" />
     <ClInclude Include="cMain.h" />
-    <ClInclude Include="Functions.h" />
     <ClInclude Include="GenerateScript.h" />
     <ClInclude Include="GUI_Base.h" />
-    <ClInclude Include="OpenTas.h" />
-    <ClInclude Include="SaveTas.h" />
     <ClInclude Include="DialogProgressBar.h" />
     <ClInclude Include="TypePanel.h" />
-    <ClInclude Include="utils.h" />
-    <ClInclude Include="StepParameters.h">
-      <Filter>Structs</Filter>
-    </ClInclude>
-    <ClInclude Include="GridEntry.h">
-      <Filter>Structs</Filter>
-    </ClInclude>
-    <ClInclude Include="Building.h">
-      <Filter>Structs</Filter>
-    </ClInclude>
-    <ClInclude Include="BuildingNameToIndex.h">
-      <Filter>Maps</Filter>
-    </ClInclude>
-    <ClInclude Include="StepNameToEnum.h">
-      <Filter>Maps</Filter>
-    </ClInclude>
     <ClInclude Include="SearchUtil.h">
       <Filter>Structs</Filter>
     </ClInclude>
     <ClInclude Include="ShortcutChanger.h" />
     <ClInclude Include="Settings.h" />
-    <ClInclude Include="ParameterChoices.h" />
     <ClInclude Include="ImportStepsPanel.h" />
     <ClInclude Include="nlohmann\json.hpp">
       <Filter>misc</Filter>
@@ -66,12 +41,24 @@
     <ClInclude Include="resource.h">
       <Filter>misc</Filter>
     </ClInclude>
-    <ClInclude Include="Inventory.h" />
-    <ClInclude Include="Orientation.h" />
-    <ClInclude Include="Priority.h" />
-    <ClInclude Include="TasFileConstants.h" />
     <ClInclude Include="CommandStack.h" />
     <ClInclude Include="SteptypeColour.h" />
+    <ClInclude Include="Data\BuildingNames.h" />
+    <ClInclude Include="Data\Inventory.h" />
+    <ClInclude Include="Data\utils.h" />
+    <ClInclude Include="Shared functions\Functions.h" />
+    <ClInclude Include="Structures\Building.h" />
+    <ClInclude Include="Structures\GridEntry.h" />
+    <ClInclude Include="Structures\Orientation.h" />
+    <ClInclude Include="Structures\ParameterChoices.h" />
+    <ClInclude Include="Structures\Priority.h" />
+    <ClInclude Include="Structures\StepModifiers.h" />
+    <ClInclude Include="Structures\StepParameters.h" />
+    <ClInclude Include="Structures\StepType.h" />
+    <ClInclude Include="TAS save file\OpenTas.h" />
+    <ClInclude Include="TAS save file\SaveTas.h" />
+    <ClInclude Include="TAS save file\TasFileConstants.h" />
+    <ClInclude Include="Shared functions\StringFunctions.h" />
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\Lua Files\control.lua">
@@ -83,6 +70,7 @@
     <CopyFileToFolders Include="..\Lua Files\settings.lua">
       <Filter>lua</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="..\Lua Files\goals.lua" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Structs">
@@ -112,8 +100,5 @@
     <ResourceCompile Include="Factorio-TAS-Generator.rc">
       <Filter>misc</Filter>
     </ResourceCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\Lua Files\goals.lua" />
   </ItemGroup>
 </Project>

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -234,7 +234,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			case e_take:
 				SetBuildingAndOrientation(&steps[i]);
 
-				from_into = GetInventoryTypeForEntity(GetInventoryType(steps[i].FromInto), building);
+				from_into = GetInventoryTypeForEntity(steps[i].inventory, building);
 
 				if (from_into == "Not Found")
 				{
@@ -248,7 +248,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			case e_put:
 				SetBuildingAndOrientation(&steps[i]);
 
-				from_into = GetInventoryTypeForEntity(GetInventoryType(steps[i].FromInto), building);
+				from_into = GetInventoryTypeForEntity(steps[i].inventory, building);
 
 				if (from_into == "Not Found")
 				{
@@ -277,7 +277,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			case e_limit:
 				SetBuildingAndOrientation(&steps[i]);
 
-				from_into = GetInventoryTypeForEntity(GetInventoryType(steps[i].FromInto), building);
+				from_into = GetInventoryTypeForEntity(steps[i].inventory, building);
 
 				if (from_into == "Not Found")
 				{
@@ -428,7 +428,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 
 void GenerateScript::SetBuildingAndOrientation(StepParameters* step)
 {
-	if (step->FromInto == inventory_types.wreck)
+	if (step->inventory == Wreck)
 	{
 		building = inventory_types.wreck;
 		return;

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -168,14 +168,14 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			wxYield();
 		}
 
-		if (steps[i].StepEnum == e_stop)
+		if (steps[i].type == e_stop)
 		{
 			break;
 		}
 
 		TransferParameters(steps[i]);
 		if (modifiers.skip) continue;
-		switch (steps[i].StepEnum)
+		switch (steps[i].type)
 		{
 			case e_game_speed:
 				speed(currentStep, amount, comment);

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -444,7 +444,7 @@ void GenerateScript::TransferParameters(StepParameters& stepParameters)
 	y_cord = to_string(stepParameters.Y);
 	amount = stepParameters.Amount;
 	item = stepParameters.Item;
-	build_orientation = stepParameters.Orientation;
+	build_orientation = stepParameters.orientation;
 	direction_to_build = stepParameters.Direction;
 	building_size = to_string(stepParameters.Size);
 	amount_of_buildings = to_string(stepParameters.Buildings);
@@ -1019,7 +1019,7 @@ void GenerateScript::build(string step, string action, string x_cord, string y_c
 
 	item = check_item_name(item);
 
-	OrientationEnum = orientation_defines_list[MapStringToOrientation[OrientationEnum]];
+	OrientationEnum = orientation_defines_list[MapStringToOrientation(OrientationEnum)];
 
 	step_list += Step(step, action, "\"build\", {" + x_cord + ", " + y_cord + "}, \"" + item + "\", " + OrientationEnum, comment);
 	total_steps += 1;

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -67,7 +67,6 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 		int size = segments.size();
 		if (size < 1) continue;
 		
-		step.Step = Capitalize(segments[0]);
 		step.OriginalX = step.X = size >= 1 && segments[1] != "" ? stod(segments[1]) : 0;
 		step.OriginalY = step.Y = size >= 2 && segments[2] != "" ? stod(segments[2]) : 0;
 		step.Amount = size >= 3 && segments[3] != "" ? segments[3] == "All" ? "All" : to_string(stoi(segments[3])) : "";
@@ -79,21 +78,17 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 		step.Comment = size >= 9 ? segments[9] : "";
 		step.Colour = size >= 10 ? segments[10] : "";
 
-		if (step.Step == "Start")
+		try
 		{
-			continue; // Ignore start steps, given that they are obsolete.
+			step.type = ToStepType(segments[0]);
 		}
-
-		auto mappedtype = MapStepNameToStepType.find(step.Step);
-		if (mappedtype == MapStepNameToStepType.end())
+		catch (...)
 		{
-			wxMessageBox("It was not possible to read line [" + std::to_string(counter) + "] as the command token [" + step.Step + "] doesn't match any commands", "Text import conversion error");
+			wxMessageBox("It was not possible to read line [" + std::to_string(counter) + "] as the command token [" + segments[0] + "] doesn't match any commands", "Text import conversion error");
 			return false;
 		}
 
-		step.StepEnum = mappedtype->second;
-
-		switch (step.StepEnum )
+		switch (step.type )
 		{
 			[[likely]] case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
@@ -242,7 +237,7 @@ void cMain::OnImportStepsIntoStepsBtnClick(wxCommandEvent& event)
 
 		PopulateGrid(grid_steps, start + i, &gridEntry);
 
-		BackgroundColorUpdate(grid_steps, start + i, step_parameters[i].StepEnum);
+		BackgroundColorUpdate(grid_steps, start + i, step_parameters[i].type);
 
 		if (step_parameters[i].Colour != "")
 		{

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -120,7 +120,7 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 			case e_limit: [[fallthrough]];
 			[[likely]] case e_put: [[fallthrough]];
 			[[likely]] case e_take:
-				step.FromInto = step.Orientation;
+				step.inventory = GetInventoryType(step.Orientation);
 				// Only here to populate extra parameters in step. Actual validation will be done on script generation
 				BuildingExists(buildingSnapshot, buildingsInSnapShot, step);
 				break;

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -76,7 +76,7 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 		step.Size = size >= 7 && segments[7] != "" ? stoi(segments[7]) : 1;
 		step.Buildings = size >= 8 && segments[8] != "" ? stoi(segments[8]) : 1;
 		step.Comment = size >= 9 ? segments[9] : "";
-		step.Colour = size >= 10 ? segments[10] : "";
+		step.colour = size >= 10 && segments[10] != "" ? wxColour(segments[10]) : wxNullColour;
 
 		try
 		{
@@ -239,9 +239,9 @@ void cMain::OnImportStepsIntoStepsBtnClick(wxCommandEvent& event)
 
 		BackgroundColorUpdate(grid_steps, start + i, step_parameters[i].type);
 
-		if (step_parameters[i].Colour != "")
+		if (step_parameters[i].colour != wxNullColour)
 		{
-			wxColour colour = wxColour(step_parameters[i].Colour);
+			wxColour colour = step_parameters[i].colour;
 			grid_steps->SetCellBackgroundColour(start + i, 1, colour);
 			grid_steps->SetCellBackgroundColour(start + i, 2, colour);
 			grid_steps->SetCellBackgroundColour(start + i, 3, colour);

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -71,8 +71,8 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 		step.OriginalY = step.Y = size >= 2 && segments[2] != "" ? stod(segments[2]) : 0;
 		step.Amount = size >= 3 && segments[3] != "" ? segments[3] == "All" ? "All" : to_string(stoi(segments[3])) : "";
 		step.Item = size >= 4 && segments[4] != "" ? Capitalize(segments[4], true) : "";
-		step.Orientation = size >= 5 && segments[5] != "" ? Capitalize(segments[5]) : "";
-		step.Direction = size >= 6 && segments[6] != "" ? Capitalize(segments[6]) : "";
+		step.orientation = size >= 5 && segments[5] != "" ? Capitalize(segments[5]) : "";
+		step.Direction = MapStringToOrientation(size >= 6 ? segments[6] : "");
 		step.Size = size >= 7 && segments[7] != "" ? stoi(segments[7]) : 1;
 		step.Buildings = size >= 8 && segments[8] != "" ? stoi(segments[8]) : 1;
 		step.Comment = size >= 9 ? segments[9] : "";
@@ -92,7 +92,7 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 		{
 			[[likely]] case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
-				step.OrientationEnum = MapStringToOrientation[step.Orientation];
+				step.OrientationEnum = MapStringToOrientation(step.orientation);
 
 				buildingsInSnapShot = ProcessBuildStep(buildingSnapshot, buildingsInSnapShot, step);
 				break;
@@ -102,8 +102,8 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 				break;
 
 			case e_priority:
-				step.priority.FromString(step.Orientation);
-				step.Orientation = "";
+				step.priority.FromString(step.orientation);
+				step.orientation = "";
 
 				// Only here to populate extra parameters in step. Actual validation will be done on script generation
 				BuildingExists(buildingSnapshot, buildingsInSnapShot, step);
@@ -120,7 +120,7 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<StepParameters>& ste
 			case e_limit: [[fallthrough]];
 			[[likely]] case e_put: [[fallthrough]];
 			[[likely]] case e_take:
-				step.inventory = GetInventoryType(step.Orientation);
+				step.inventory = GetInventoryType(step.orientation);
 				// Only here to populate extra parameters in step. Actual validation will be done on script generation
 				BuildingExists(buildingSnapshot, buildingsInSnapShot, step);
 				break;

--- a/src/Shared functions/StringFunctions.cpp
+++ b/src/Shared functions/StringFunctions.cpp
@@ -1,0 +1,11 @@
+#include "StringFunctions.h"
+
+using std::tolower;
+
+string to_lower(const string str)
+{
+	string r_str = str;
+	for (int i = 0; i < str.size(); i++)
+		r_str[i] = tolower(str[i]);
+	return r_str;
+}

--- a/src/Shared functions/StringFunctions.h
+++ b/src/Shared functions/StringFunctions.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+
+using std::string;
+
+string to_lower(const string str);

--- a/src/Structures/GridEntry.h
+++ b/src/Structures/GridEntry.h
@@ -15,4 +15,10 @@ struct GridEntry
 	wxString BuildingSize;
 	wxString AmountOfBuildings;
 	wxString Comment;
+	
+	//Alias'es'
+	wxString& Recipe{Item}; // Item alias
+	wxString& Technology{Item}; //Item alias
+	wxString& Inventory{BuildingOrientation}; //Orientation alias
+	wxString& Priority{BuildingOrientation}; //Orientation alias
 };

--- a/src/Structures/Orientation.h
+++ b/src/Structures/Orientation.h
@@ -4,6 +4,8 @@
 #include <map>
 #include <string>
 
+#include "../Shared functions/StringFunctions.h"
+
 /*
 Orientation and Direction is the same type, but different fields.
 	Orientation is used for the direction a building is facing
@@ -49,10 +51,28 @@ enum Orientation
 	West,
 };
 
-static inline std::map<std::string, Orientation> MapStringToOrientation
+static inline std::map<std::string, Orientation> string_to_orientation
 {
 	{orientation_list[North], North},
 	{orientation_list[East], East},
 	{orientation_list[South], South},
-	{orientation_list[West], West}
+	{orientation_list[West], West},
+
+	{to_lower(orientation_list[North]), North},
+	{to_lower(orientation_list[East]), East},
+	{to_lower(orientation_list[South]), South},
+	{to_lower(orientation_list[West]), West},
 };
+
+// Returns the Orientation that matches the string, defaults to North
+Orientation static MapStringToOrientation(const std::string str)
+{
+	auto mapped = string_to_orientation.find(str);
+	return mapped != string_to_orientation.end() ? mapped->second : North;
+}
+
+// Returns the Orientation that matches the string, defaults to North
+Orientation static MapStringToOrientation(const wxString str)
+{
+	return MapStringToOrientation(str.ToStdString());
+}

--- a/src/Structures/StepParameters.cpp
+++ b/src/Structures/StepParameters.cpp
@@ -8,12 +8,6 @@ StepParameters::StepParameters(double InitialX, double InitialY)
 	Y = InitialY;
 	OriginalX = InitialX;
 	OriginalY = InitialY;
-
-	OrientationEnum = North;
-	type = e_stop;
-	Size = 1;
-	Buildings = 1;
-	BuildingIndex = 0;
 }
 
 void StepParameters::Reset()
@@ -93,7 +87,7 @@ string StepParameters::ToString()
 
 		[[likely]] case e_put:
 		[[likely]] case e_take:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + GetInventoryTypeForEntity(inventory, FindBuildingName(BuildingIndex)) + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + inventory_types_list[inventory] + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_launch:
 		[[likely]] case e_walk:

--- a/src/Structures/StepParameters.cpp
+++ b/src/Structures/StepParameters.cpp
@@ -1,5 +1,7 @@
 #include "StepParameters.h"
 
+#include "../Data/BuildingNames.h"
+
 StepParameters::StepParameters(double InitialX, double InitialY)
 {
 	X = InitialX;
@@ -91,7 +93,7 @@ string StepParameters::ToString()
 
 		[[likely]] case e_put:
 		[[likely]] case e_take:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + FromInto + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + GetInventoryTypeForEntity(inventory, FindBuildingName(BuildingIndex)) + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_launch:
 		[[likely]] case e_walk:

--- a/src/Structures/StepParameters.cpp
+++ b/src/Structures/StepParameters.cpp
@@ -8,7 +8,7 @@ StepParameters::StepParameters(double InitialX, double InitialY)
 	OriginalY = InitialY;
 
 	OrientationEnum = North;
-	StepEnum = e_stop;
+	type = e_stop;
 	Size = 1;
 	Buildings = 1;
 	BuildingIndex = 0;
@@ -50,7 +50,8 @@ void StepParameters::Next()
 string StepParameters::ToString()
 {
 	const string string_end = ";" + Comment + ";" + Colour + ";" + Modifiers.ToString() + ";";
-	switch (StepEnum)
+	const string steptype = StepNames[type];
+	switch (type)
 	{
 		case e_never_idle:
 		case e_keep_crafting:
@@ -58,57 +59,57 @@ string StepParameters::ToString()
 		case e_keep_walking:
 		case e_pause:
 		case e_save:
-			return Step + ";" + ";" + ";" + ";" + ";" + ";" + ";" + ";" + string_end;
+			return steptype + ";" + ";" + ";" + ";" + ";" + ";" + ";" + ";" + string_end;
 
 		case e_stop:
 		case e_game_speed:
 		case e_idle:
 		case e_pick_up:
-			return Step + ";" + ";" + ";" + Amount + ";" + ";" + ";" + ";" + ";" + string_end;
+			return steptype + ";" + ";" + ";" + Amount + ";" + ";" + ";" + ";" + ";" + string_end;
 
 		case e_build:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_craft:
-			return Step + ";" + ";" + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + string_end;
+			return steptype + ";" + ";" + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_recipe:
 		case e_filter:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_limit:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_rotate:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_mine:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_priority:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + priority.ToString() + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + priority.ToString() + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		[[likely]] case e_put:
 		[[likely]] case e_take:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + FromInto + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + FromInto + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_launch:
 		[[likely]] case e_walk:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + ";" + ";" + ";" + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + ";" + ";" + ";" + string_end;
 
 		case e_tech:
-			return Step + ";" + ";" + ";" + ";" + Item + ";" + ";" + ";" + ";" + string_end;
+			return steptype + ";" + ";" + ";" + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_drop:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + ";" + ";" + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + ";" + ";" + string_end;
 
 		case e_shoot:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + ";" + ";" + ";" + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + ";" + ";" + ";" + string_end;
 		case e_throw:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + ";" + ";" + ";" + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		default:
-			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 	}
 }
 

--- a/src/Structures/StepParameters.cpp
+++ b/src/Structures/StepParameters.cpp
@@ -64,30 +64,30 @@ string StepParameters::ToString()
 			return steptype + ";" + ";" + ";" + Amount + ";" + ";" + ";" + ";" + ";" + string_end;
 
 		case e_build:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + orientation + ";" + orientation_list[Direction] + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_craft:
 			return steptype + ";" + ";" + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_recipe:
 		case e_filter:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + orientation_list[Direction] + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_limit:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + orientation + ";" + orientation_list[Direction] + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_rotate:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + orientation_list[Direction] + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_mine:
 			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_priority:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + priority.ToString() + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + ";" + priority.ToString() + ";" + orientation_list[Direction] + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		[[likely]] case e_put:
 		[[likely]] case e_take:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + inventory_types_list[inventory] + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + inventory_types_list[inventory] + ";" + orientation_list[Direction] + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 
 		case e_launch:
 		[[likely]] case e_walk:
@@ -97,7 +97,7 @@ string StepParameters::ToString()
 			return steptype + ";" + ";" + ";" + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		case e_drop:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + Orientation + ";" + ";" + ";" + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + orientation + ";" + ";" + ";" + string_end;
 
 		case e_shoot:
 			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + ";" + ";" + ";" + string_end;
@@ -105,7 +105,7 @@ string StepParameters::ToString()
 			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + ";" + Item + ";" + ";" + ";" + ";" + string_end;
 
 		default:
-			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
+			return steptype + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + orientation + ";" + orientation_list[Direction] + ";" + to_string(Size) + ";" + to_string(Buildings) + string_end;
 	}
 }
 

--- a/src/Structures/StepParameters.cpp
+++ b/src/Structures/StepParameters.cpp
@@ -18,28 +18,20 @@ void StepParameters::Reset()
 
 void StepParameters::Next()
 {
-	if (Direction == orientation_list[North])
+	switch (Direction)
 	{
-		Y -= Size;
-		return;
-	}
-
-	if (Direction == orientation_list[South])
-	{
-		Y += Size;
-		return;
-	}
-
-	if (Direction == orientation_list[East])
-	{
-		X += Size;
-		return;
-	}
-
-	if (Direction == orientation_list[West])
-	{
-		X -= Size;
-		return;
+		case North: 
+			Y -= Size; 
+			break;
+		case South: 
+			Y += Size; 
+			break;
+		case East: 
+			X += Size; 
+			break;
+		case West: 
+			X -= Size; 
+			break;
 	}
 }
 
@@ -143,7 +135,7 @@ bool StepParameters::operator==(const StepParameters& toCompare)
 
 	if (toCompare.X == X)
 	{
-		if (toCompare.Direction == orientation_list[South])
+		if (toCompare.Direction == South)
 		{
 			if (toCompare.Y > Y)
 			{
@@ -159,7 +151,7 @@ bool StepParameters::operator==(const StepParameters& toCompare)
 			}
 		}
 
-		if (toCompare.Direction == orientation_list[North])
+		if (toCompare.Direction == North)
 		{
 			if (toCompare.Y < Y)
 			{
@@ -178,7 +170,7 @@ bool StepParameters::operator==(const StepParameters& toCompare)
 
 	if (toCompare.Y == Y)
 	{
-		if (toCompare.Direction == orientation_list[East])
+		if (toCompare.Direction == East)
 		{
 			if (toCompare.X > X)
 			{
@@ -194,7 +186,7 @@ bool StepParameters::operator==(const StepParameters& toCompare)
 			}
 		}
 
-		if (toCompare.Direction == orientation_list[West])
+		if (toCompare.Direction == West)
 		{
 			if (toCompare.X < X)
 			{

--- a/src/Structures/StepParameters.cpp
+++ b/src/Structures/StepParameters.cpp
@@ -45,7 +45,7 @@ void StepParameters::Next()
 
 string StepParameters::ToString()
 {
-	const string string_end = ";" + Comment + ";" + Colour + ";" + Modifiers.ToString() + ";";
+	const string string_end = ";" + Comment + ";" + colour.GetAsString().ToStdString() + ";" + Modifiers.ToString() + ";";
 	const string steptype = StepNames[type];
 	switch (type)
 	{

--- a/src/Structures/StepParameters.h
+++ b/src/Structures/StepParameters.h
@@ -28,9 +28,8 @@ struct StepParameters
 	StepModifiers Modifiers;
 
 	Orientation OrientationEnum;
-	StepType StepEnum;
+	StepType type;
 
-	string Step;
 	string Amount;
 	string Item;
 	string FromInto;

--- a/src/Structures/StepParameters.h
+++ b/src/Structures/StepParameters.h
@@ -3,7 +3,6 @@
 #include <wx/colour.h>
 
 #include <string>
-#include <fstream>
 
 #include "Building.h"
 #include "StepType.h"
@@ -14,7 +13,6 @@
 #include "../Data/Inventory.h"
 
 using std::string;
-using std::ofstream;
 using std::to_string;
 
 struct StepParameters

--- a/src/Structures/StepParameters.h
+++ b/src/Structures/StepParameters.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <wx/colour.h>
+
 #include <string>
 #include <fstream>
 
@@ -40,7 +42,7 @@ struct StepParameters
 	string Direction;
 	PriorityStruct priority;
 	string Comment;
-	string Colour;
+	wxColour colour;
 
 	void Reset();
 	void Next();

--- a/src/Structures/StepParameters.h
+++ b/src/Structures/StepParameters.h
@@ -38,8 +38,8 @@ struct StepParameters
 
 	string Amount;
 	string Item;
-	string Orientation;
-	string Direction;
+	string orientation;
+	Orientation Direction = North;
 	PriorityStruct priority;
 	string Comment;
 	wxColour colour;

--- a/src/Structures/StepParameters.h
+++ b/src/Structures/StepParameters.h
@@ -23,14 +23,15 @@ struct StepParameters
 	double Y;
 	double OriginalX;
 	double OriginalY;
-	int Size;
-	int Buildings;
-	int BuildingIndex;
+
+	int Size = 1;
+	int Buildings = 1;
+	int BuildingIndex = 0;
 
 	StepModifiers Modifiers;
 
-	Orientation OrientationEnum;
-	StepType type;
+	Orientation OrientationEnum = North;
+	StepType type = e_stop;
 	InventoryType inventory = Wreck;
 
 	string Amount;

--- a/src/Structures/StepParameters.h
+++ b/src/Structures/StepParameters.h
@@ -9,6 +9,8 @@
 #include "Priority.h"
 #include "StepModifiers.h"
 
+#include "../Data/Inventory.h"
+
 using std::string;
 using std::ofstream;
 using std::to_string;
@@ -29,10 +31,10 @@ struct StepParameters
 
 	Orientation OrientationEnum;
 	StepType type;
+	InventoryType inventory = Wreck;
 
 	string Amount;
 	string Item;
-	string FromInto;
 	string Orientation;
 	string Direction;
 	PriorityStruct priority;

--- a/src/TAS save file/OpenTas.cpp
+++ b/src/TAS save file/OpenTas.cpp
@@ -214,7 +214,7 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 			case e_limit:
 			case e_put:
 			case e_take:
-				step.FromInto = step.Orientation;
+				step.inventory = GetInventoryType(step.Orientation);
 				// Only here to populate extra parameters in step. Actual validation will be done on script generation
 				BuildingExists(buildingSnapshot, buildingsInSnapShot, step);
 				break;
@@ -345,7 +345,7 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 			case e_limit:
 			case e_put:
 			case e_take:
-				step.FromInto = step.Orientation;
+				step.inventory = GetInventoryType(step.Orientation);
 				break;
 			default:
 				break;
@@ -471,7 +471,7 @@ bool OpenTas::extract_templates(std::ifstream& file, DialogProgressBar* dialog_p
 			case e_limit:
 			case e_put:
 			case e_take:
-				step.FromInto = step.Orientation;
+				step.inventory = GetInventoryType(step.Orientation);
 				break;
 			default:
 				break;

--- a/src/TAS save file/OpenTas.cpp
+++ b/src/TAS save file/OpenTas.cpp
@@ -162,7 +162,6 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 			step.OriginalY = step.Y;
 		}
 
-		step.Step = Capitalize(segments[0]);
 		step.Amount = Capitalize(segments[3]);
 		step.Item = Capitalize(segments[4], true);
 		step.Orientation = Capitalize(segments[5]);
@@ -172,21 +171,18 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 		step.Comment = segment_size == step_segment_size || segment_size == step_segment_size_without_colour ? segments[9] : "";
 		step.Colour = segment_size == step_segment_size ? segments[10] : "";
 		step.Modifiers.FromString(segment_size == step_segment_size ? segments[11] : "");
-		
-		if (step.Step == "Start")
+
+		try
 		{
-			continue; // Ignore start steps, given that they are obsolete.
+			step.type = ToStepType(segments[0]);
+		}
+		catch (...)
+		{
+			if (segments[0] == "Start" || segments[0] == "start") continue; // Ignore start steps, given that they are obsolete.
+			else return Invalid;
 		}
 
-		auto mappedtype = MapStepNameToStepType.find(step.Step);
-		if (mappedtype == MapStepNameToStepType.end())
-		{
-			return Invalid;
-		}
-
-		step.StepEnum = mappedtype->second;
-
-		switch (step.StepEnum)
+		switch (step.type)
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
@@ -318,27 +314,23 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 			step.Buildings = stoi(segments[9]);
 		}
 
-		step.Step = Capitalize(segments[1]);
 		step.Amount = Capitalize(segments[4]);
 		step.Item = Capitalize(segments[5], true);
 		step.Orientation = Capitalize(segments[6]);
 		step.Direction = Capitalize(segments[7]);
 		step.Comment = comment;
 
-		if (step.Step == "Start")
+		try
 		{
-			continue; // Ignore start steps, given that they are obsolete.
+			step.type = ToStepType(segments[1]);
+		}
+		catch (...)
+		{
+			if (segments[1] == "Start" || segments[1] == "start") continue; // Ignore start steps, given that they are obsolete.
+			else return Invalid;
 		}
 
-		auto mappedtype = MapStepNameToStepType.find(step.Step);
-		if (mappedtype == MapStepNameToStepType.end())
-		{
-			return false;
-		}
-
-		step.StepEnum = mappedtype->second;
-
-		switch (step.StepEnum)
+		switch (step.type)
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
@@ -447,27 +439,24 @@ bool OpenTas::extract_templates(std::ifstream& file, DialogProgressBar* dialog_p
 			step.Buildings = stoi(segments[9]);
 		}
 
-		step.Step = Capitalize(segments[1]);
+		
 		step.Amount = Capitalize(segments[4]);
 		step.Item = Capitalize(segments[5], true);
 		step.Orientation = Capitalize(segments[6]);
 		step.Direction = Capitalize(segments[7]);
 		step.Comment = comment;
 
-		if (step.Step == "Start")
+		try
 		{
-			continue; // Ignore start steps, given that they are obsolete.
+			step.type = ToStepType(segments[1]);
+		}
+		catch (...)
+		{
+			if (segments[1] == "Start" || segments[1] == "start") continue; // Ignore start steps, given that they are obsolete.
+			else return Invalid;
 		}
 
-		auto mappedtype = MapStepNameToStepType.find(step.Step);
-		if (mappedtype == MapStepNameToStepType.end())
-		{
-			return false;
-		}
-
-		step.StepEnum = mappedtype->second;
-
-		switch (step.StepEnum)
+		switch (step.type)
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];

--- a/src/TAS save file/OpenTas.cpp
+++ b/src/TAS save file/OpenTas.cpp
@@ -164,8 +164,8 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 
 		step.Amount = Capitalize(segments[3]);
 		step.Item = Capitalize(segments[4], true);
-		step.Orientation = Capitalize(segments[5]);
-		step.Direction = Capitalize(segments[6]);
+		step.orientation = Capitalize(segments[5]);
+		step.Direction = MapStringToOrientation(segments[6]);
 		step.Size = segments[7] != "" ? stoi(segments[7]) : 1;
 		step.Buildings = segments[8] != "" ? stoi(segments[8]) : 1;
 		step.Comment = segment_size == step_segment_size || segment_size == step_segment_size_without_colour ? segments[9] : "";
@@ -186,7 +186,7 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
-				step.OrientationEnum = MapStringToOrientation[step.Orientation];
+				step.OrientationEnum = MapStringToOrientation(step.orientation);
 
 				buildingsInSnapShot = ProcessBuildStep(buildingSnapshot, buildingsInSnapShot, step);
 				break;
@@ -196,8 +196,8 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 				break;
 
 			case e_priority:
-				step.priority.FromString(step.Orientation);
-				step.Orientation = "";
+				step.priority.FromString(step.orientation);
+				step.orientation = "";
 
 				// Only here to populate extra parameters in step. Actual validation will be done on script generation
 				BuildingExists(buildingSnapshot, buildingsInSnapShot, step);
@@ -214,7 +214,7 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 			case e_limit:
 			case e_put:
 			case e_take:
-				step.inventory = GetInventoryType(step.Orientation);
+				step.inventory = GetInventoryType(step.orientation);
 				// Only here to populate extra parameters in step. Actual validation will be done on script generation
 				BuildingExists(buildingSnapshot, buildingsInSnapShot, step);
 				break;
@@ -316,8 +316,8 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 
 		step.Amount = Capitalize(segments[4]);
 		step.Item = Capitalize(segments[5], true);
-		step.Orientation = Capitalize(segments[6]);
-		step.Direction = Capitalize(segments[7]);
+		step.orientation = Capitalize(segments[6]);
+		step.Direction = MapStringToOrientation(segments[7]);
 		step.Comment = comment;
 
 		try
@@ -334,18 +334,18 @@ bool OpenTas::extract_groups(std::ifstream& file, DialogProgressBar* dialog_prog
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
-				step.OrientationEnum = MapStringToOrientation[step.Orientation];
+				step.OrientationEnum = MapStringToOrientation(step.orientation);
 				break;
 
 			case e_priority:
-				step.priority.FromString(step.Orientation);
-				step.Orientation = "";
+				step.priority.FromString(step.orientation);
+				step.orientation = "";
 				break;
 
 			case e_limit:
 			case e_put:
 			case e_take:
-				step.inventory = GetInventoryType(step.Orientation);
+				step.inventory = GetInventoryType(step.orientation);
 				break;
 			default:
 				break;
@@ -442,8 +442,8 @@ bool OpenTas::extract_templates(std::ifstream& file, DialogProgressBar* dialog_p
 		
 		step.Amount = Capitalize(segments[4]);
 		step.Item = Capitalize(segments[5], true);
-		step.Orientation = Capitalize(segments[6]);
-		step.Direction = Capitalize(segments[7]);
+		step.orientation = Capitalize(segments[6]);
+		step.Direction = MapStringToOrientation(segments[7]);
 		step.Comment = comment;
 
 		try
@@ -460,18 +460,18 @@ bool OpenTas::extract_templates(std::ifstream& file, DialogProgressBar* dialog_p
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType[step.Item];
-				step.OrientationEnum = MapStringToOrientation[step.Orientation];
+				step.OrientationEnum = MapStringToOrientation(step.orientation);
 				break;
 
 			case e_priority:
-				step.priority.FromString(step.Orientation);
-				step.Orientation = "";
+				step.priority.FromString(step.orientation);
+				step.orientation = "";
 				break;
 
 			case e_limit:
 			case e_put:
 			case e_take:
-				step.inventory = GetInventoryType(step.Orientation);
+				step.inventory = GetInventoryType(step.orientation);
 				break;
 			default:
 				break;

--- a/src/TAS save file/OpenTas.cpp
+++ b/src/TAS save file/OpenTas.cpp
@@ -169,7 +169,7 @@ Category OpenTas::extract_steps(std::ifstream& file, DialogProgressBar* dialog_p
 		step.Size = segments[7] != "" ? stoi(segments[7]) : 1;
 		step.Buildings = segments[8] != "" ? stoi(segments[8]) : 1;
 		step.Comment = segment_size == step_segment_size || segment_size == step_segment_size_without_colour ? segments[9] : "";
-		step.Colour = segment_size == step_segment_size ? segments[10] : "";
+		step.colour = segment_size == step_segment_size && segments[10] != "" ? wxColour(segments[10]) : wxNullColour;
 		step.Modifiers.FromString(segment_size == step_segment_size ? segments[11] : "");
 
 		try

--- a/src/TemplatePage.cpp
+++ b/src/TemplatePage.cpp
@@ -30,7 +30,7 @@ void cMain::UpdateTemplateGrid(vector<StepParameters>& steps)
 	{
 		GridEntry gridEntry = PrepareStepParametersForGrid(&steps[i]);
 		PopulateGrid(grid_template, i, &gridEntry);
-		BackgroundColorUpdate(grid_template, i, steps[i].StepEnum);
+		BackgroundColorUpdate(grid_template, i, steps[i].type);
 	}
 }
 
@@ -151,7 +151,7 @@ void cMain::OnTemplateAddStepClicked(wxCommandEvent& event)
 	grid_template->InsertRows(row);
 	GridEntry gridEntry = PrepareStepParametersForGrid(&stepParameters);
 	PopulateGrid(grid_template, row, &gridEntry);
-	BackgroundColorUpdate(grid_template, row, stepParameters.StepEnum);
+	BackgroundColorUpdate(grid_template, row, stepParameters.type);
 
 	string key = cmb_choose_template->GetValue().ToStdString();
 	vector<StepParameters> list = template_map[key]; 

--- a/src/TemplatePage.cpp
+++ b/src/TemplatePage.cpp
@@ -379,12 +379,11 @@ void cMain::TemplateAlterStep(StepParameters& step, const int direction, int x_o
 			+ amount_off
 		);
 	}
-	auto orientation = MapStringToOrientation.find(step.Orientation);
-	auto build_direction = MapStringToOrientation.find(step.Direction);
-	if (orientation != MapStringToOrientation.end())
-		step.Orientation = orientation_list[tranform(orientation->second, (template_direction_choice)direction)];
-	if (build_direction != MapStringToOrientation.end())
-		step.Direction = orientation_list[tranform(build_direction->second, (template_direction_choice)direction)];
+	auto orientation = string_to_orientation.find(step.orientation);
+	if (orientation != string_to_orientation.end())
+		step.orientation = orientation_list[tranform(orientation->second, (template_direction_choice)direction)];
+	
+	step.Direction = tranform(step.Direction, (template_direction_choice)direction);
 
 	if (step.X == invalidX) return;
 	

--- a/src/WalkPanel.cpp
+++ b/src/WalkPanel.cpp
@@ -23,7 +23,7 @@ void cMain::SetupWalkPanelUnicodeCharacters()
 int cMain::AddWalkScanStartRow()
 {
 	for (int i = StepGridData.size() - 1; i >= 0; i--)
-		if (!control_types.contains(StepGridData[i].StepEnum))
+		if (!control_types.contains(StepGridData[i].type))
 			return i;
 		
 	return 0;
@@ -31,7 +31,7 @@ int cMain::AddWalkScanStartRow()
 pair<double, double> cMain::AddWalkScanCurrentPosition()
 {
 	for (int i = StepGridData.size() - 1; i >= 0; i--)
-		if (StepGridData[i].StepEnum == e_walk)
+		if (StepGridData[i].type == e_walk)
 			return pair<double, double> {StepGridData[i].X, StepGridData[i].Y};
 	
 	return pair<double, double>{0, 0};
@@ -44,7 +44,7 @@ void cMain::CreateWalkStep(int x_modifier, int y_modifier)
 	auto increment = walk_panel_increment_spin->GetValue();
 
 	auto step = StepParameters(x + increment * x_modifier, y + increment * y_modifier);
-	step.StepEnum = e_walk; step.Step = StepNames[e_walk];
+	step.type = e_walk;
 	stack.Push({
 		.row = row,
 		.type = T_ADD,

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -601,7 +601,7 @@ vector<tuple<int, StepParameters>> cMain::AddStep(int row, StepParameters stepPa
 				if (check_furnace->IsChecked() && (to_check == struct_auto_put_furnace_list.stone || to_check == struct_auto_put_furnace_list.steel))
 				{
 					stepParameters.Item = struct_fuel_list.coal;
-					stepParameters.FromInto = inventory_types.fuel;
+					stepParameters.inventory = Fuel;
 
 					UpdateStepGrid(row + 1, &stepParameters);
 					returnValue.push_back({row + 1, stepParameters});
@@ -611,7 +611,7 @@ vector<tuple<int, StepParameters>> cMain::AddStep(int row, StepParameters stepPa
 				if (check_burner->IsChecked() && (to_check == struct_auto_put_burner_list.burner_mining_drill || to_check == struct_auto_put_burner_list.burner_inserter || to_check == struct_auto_put_burner_list.boiler))
 				{
 					stepParameters.Item = struct_fuel_list.coal;
-					stepParameters.FromInto = inventory_types.fuel;
+					stepParameters.inventory = Fuel;
 
 					UpdateStepGrid(row + 1, &stepParameters);
 					returnValue.push_back({row + 1, stepParameters});
@@ -621,7 +621,7 @@ vector<tuple<int, StepParameters>> cMain::AddStep(int row, StepParameters stepPa
 				if (check_lab->IsChecked() && to_check == struct_science_list.lab)
 				{
 					stepParameters.Item = "Automation science pack";
-					stepParameters.FromInto = inventory_types.input;
+					stepParameters.inventory = Input;
 
 					UpdateStepGrid(row + 1, &stepParameters);
 					returnValue.push_back({row + 1, stepParameters});
@@ -649,7 +649,7 @@ vector<tuple<int, StepParameters>> cMain::AddStep(int row, StepParameters stepPa
 					stepParameters.type = e_put;
 					stepParameters.Amount = to_string(stoi(recipe[i + 1]) * multiplier);
 					stepParameters.Item = recipe[i];
-					stepParameters.FromInto = inventory_types.input;
+					stepParameters.inventory = Input;
 
 					UpdateStepGrid(row + 1, &stepParameters);
 					returnValue.push_back({row + 1, stepParameters});
@@ -1635,6 +1635,93 @@ void cMain::OnAddAltMenuSelected(wxCommandEvent& event)
 	event.Skip();
 }
 
+void cMain::UpdateParametersChangeType(wxCommandEvent& event, StepType step)
+{
+	switch (step)
+	{
+		case e_build:
+			OnBuildMenuSelected(event);
+			break;
+		case e_craft:
+			OnCraftMenuSelected(event);
+			break;
+		case e_game_speed:
+			OnGameSpeedMenuSelected(event);
+			break;
+		case e_pause:
+			OnPauseMenuSelected(event);
+			break;
+		case e_save:
+			OnSaveMenuSelected(event);
+			break;
+		case e_never_idle:
+			OnNeverIdleMenuSelected(event);
+			break;
+		case e_keep_walking:
+			OnKeepWalkingMenuSelected(event);
+			break;
+		case e_keep_crafting:
+			OnKeepCraftingMenuSelected(event);
+			break;
+		case e_keep_on_path:
+			OnKeepOnPathMenuSelected(event);
+			break;
+		case e_recipe:
+			OnRecipeMenuChosen(event);
+			break;
+		case e_limit:
+			OnLimitMenuSelected(event);
+			break;
+		case e_filter:
+			OnFilterMenuSelected(event);
+			break;
+		case e_rotate:
+			OnRotateMenuSelected(event);
+			break;
+		case e_priority:
+			OnPriorityMenuSelected(event);
+			break;
+		case e_put:
+			OnPutMenuSelected(event);
+			break;
+		case e_take:
+			OnTakeMenuSelected(event);
+			break;
+		case e_mine:
+			OnMineMenuSelected(event);
+			break;
+		case e_launch:
+			OnLaunchMenuSelected(event);
+			break;
+		case e_walk:
+			OnWalkMenuSelected(event);
+			break;
+		case e_tech:
+			OnTechMenuSelected(event);
+			break;
+		case e_drop:
+			OnDropMenuSelected(event);
+			break;
+		case e_pick_up:
+			OnPickUpMenuSelected(event);
+			break;
+		case e_idle:
+			OnIdleMenuSelected(event);
+			break;
+		case e_shoot:
+			OnShootMenuSelected(event);
+			break;
+		case e_throw:
+			OnThrowMenuSelected(event);
+			break;
+		case e_cancel_crafting:
+			OnCancelCraftingMenuSelected(event);
+			break;
+		default:
+			break;
+	}
+}
+
 void cMain::UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event, bool changeType)
 {
 	auto& modifiers = gridEntry->Modifiers;
@@ -1650,104 +1737,25 @@ void cMain::UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event, bool c
 	StepType step = ToStepType(gridEntry->Step.ToStdString());
 	int parameters = listStepTypeToParameterChoices[step];
 
-	string OrientationEnum = gridEntry->BuildingOrientation.ToStdString();
-	float speed;
-	size_t pos = OrientationEnum.find(",");
+	string orientation_string = gridEntry->BuildingOrientation.ToStdString();
+	size_t pos = orientation_string.find(",");
 
-	switch (step)
-	{
-		case e_build:
-			if (changeType) OnBuildMenuSelected(event);
-			break;
-		case e_craft:
-			if (changeType) OnCraftMenuSelected(event);
-			break;
-		case e_game_speed:
-			if (changeType) OnGameSpeedMenuSelected(event);
-			speed = stof(gridEntry->Amount.ToStdString()) * 100.0;
-			spin_amount->SetValue(speed);
-			break;
-		case e_pause:
-			if (changeType) OnPauseMenuSelected(event);
-			break;
-		case e_save:
-			if (changeType) OnSaveMenuSelected(event);
-			break;
-		case e_never_idle:
-			if (changeType) OnNeverIdleMenuSelected(event);
-			break;
-		case e_keep_walking:
-			if (changeType) OnKeepWalkingMenuSelected(event);
-			break;
-		case e_keep_crafting:
-			if (changeType) OnKeepCraftingMenuSelected(event);
-			break;
-		case e_keep_on_path:
-			if (changeType) OnKeepOnPathMenuSelected(event);
-			break;
-		case e_recipe:
-			if (changeType) OnRecipeMenuChosen(event);
-			break;
-		case e_limit:
-			if (changeType) OnLimitMenuSelected(event);
-			break;
-		case e_filter:
-			if (changeType) OnFilterMenuSelected(event);
-			break;
-		case e_rotate:
-			if (changeType) OnRotateMenuSelected(event);
-			break;
-		case e_priority:
-			if (changeType) OnPriorityMenuSelected(event);
-			break;
-		case e_put:
-			if (changeType) OnPutMenuSelected(event);
-			break;
-		case e_take:
-			if (changeType) OnTakeMenuSelected(event);
-			break;
-		case e_mine:
-			if (changeType) OnMineMenuSelected(event);
-			break;
-		case e_launch:
-			if (changeType) OnLaunchMenuSelected(event);
-			break;
-		case e_walk:
-			if (changeType) OnWalkMenuSelected(event);
-			break;
-		case e_tech:
-			if (changeType) OnTechMenuSelected(event);
-			break;
-		case e_drop:
-			if (changeType) OnDropMenuSelected(event);
-			break;
-		case e_pick_up:
-			if (changeType) OnPickUpMenuSelected(event);
-			break;
-		case e_idle:
-			if (changeType) OnIdleMenuSelected(event);
-			break;
-		case e_shoot:
-			if (changeType) OnShootMenuSelected(event);
-			break;
-		case e_throw:
-			if (changeType) OnThrowMenuSelected(event);
-			break;
-		case e_cancel_crafting:
-			if (changeType) OnCancelCraftingMenuSelected(event);
-			break;
-		default:
-			break;
-	}
+	if (changeType) 
+		UpdateParametersChangeType(event, step);
 
 	using enum choice_bit_vector;
 	if (parameters & x_coordinate) spin_x->SetValue(gridEntry->X);
 	if (parameters & y_coordinate) spin_y->SetValue(gridEntry->Y);
-	if (parameters & amount) spin_amount->SetValue(gridEntry->Amount);
+	if (parameters & amount) 
+		spin_amount->SetValue(
+			step != e_game_speed ? 
+			gridEntry->Amount : 
+			to_string(round(stof(gridEntry->Amount.ToStdString()) * 100.0))
+		);
 	if (parameters & item) cmb_item->SetValue(gridEntry->Item);
 	if (parameters & from_to) cmb_from_into->SetValue(gridEntry->BuildingOrientation);
-	if (parameters & input) radio_input->Select(Priority::MapNameToType[OrientationEnum.substr(0, pos)]);
-	if (parameters & output) radio_output->Select(Priority::MapNameToType[OrientationEnum.substr(pos + 1)]);
+	if (parameters & input) radio_input->Select(Priority::MapNameToType[orientation_string.substr(0, pos)]);
+	if (parameters & output) radio_output->Select(Priority::MapNameToType[orientation_string.substr(pos + 1)]);
 	if (parameters & building_orientation) cmb_building_orientation->SetValue(gridEntry->BuildingOrientation);
 	if (parameters & direction_to_build) cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
 	if (parameters & building_size) spin_building_size->SetValue(gridEntry->BuildingSize);
@@ -1847,7 +1855,7 @@ StepParameters cMain::ExtractStepParameters()
 	stepParameters.type = ToStepType(ExtractStep());
 	stepParameters.Amount = ExtractAmount();
 	stepParameters.Item = Capitalize(cmb_item->GetValue(), true);
-	stepParameters.FromInto = Capitalize(cmb_from_into->GetValue());
+	stepParameters.inventory = GetInventoryType(Capitalize(cmb_from_into->GetValue()));
 	stepParameters.Orientation = Capitalize(cmb_building_orientation->GetValue());
 	stepParameters.Direction = Capitalize(cmb_direction_to_build->GetValue());
 	stepParameters.Size = spin_building_size->GetValue();
@@ -1953,7 +1961,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 		case e_craft:
 		case e_cancel_crafting:
 			gridEntry.Amount = stepParameters->Amount;
-			gridEntry.Item = stepParameters->Item;
+			gridEntry.Recipe = stepParameters->Item;
 			break;
 
 		case e_throw:
@@ -2014,7 +2022,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Amount = stepParameters->Amount;
 			gridEntry.Item = stepParameters->Item;
-			gridEntry.BuildingOrientation = stepParameters->FromInto;
+			gridEntry.Inventory = inventory_types_list[stepParameters->inventory];
 			gridEntry.DirectionToBuild = stepParameters->Direction;
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
@@ -2028,7 +2036,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			gridEntry.X = std::to_string(stepParameters->X);
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Amount = stepParameters->Amount;
-			gridEntry.Item = stepParameters->Item;
+			gridEntry.Recipe = stepParameters->Item;
 			gridEntry.DirectionToBuild = stepParameters->Direction;
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
@@ -2048,7 +2056,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 		case e_priority:
 			gridEntry.X = std::to_string(stepParameters->X);
 			gridEntry.Y = std::to_string(stepParameters->Y);
-			gridEntry.BuildingOrientation = stepParameters->priority.ToString();
+			gridEntry.Priority = stepParameters->priority.ToString();
 			gridEntry.DirectionToBuild = stepParameters->Direction;
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
@@ -2192,7 +2200,7 @@ bool cMain::ValidateStep(const int& row, StepParameters& stepParameters, bool va
 
 		case e_put:
 		case e_take:
-			if (stepParameters.FromInto != "Wreck" && !BuildingExists(BuildingsSnapShot, amountOfBuildings, stepParameters))
+			if (stepParameters.inventory != Wreck && !BuildingExists(BuildingsSnapShot, amountOfBuildings, stepParameters))
 			{
 				wxMessageBox("Building location doesn't exist.\n1. Please use exactly the same coordinates as you used to build \n2. Check that you have not removed the building(s)\n3. Check that you are not putting this step before the Build step", "Please use the same coordinates");
 				return false;
@@ -2347,9 +2355,9 @@ bool cMain::IsValidTechnologyStep(StepParameters& stepParameters)
 
 bool cMain::CheckTakePut(StepParameters& stepParameters)
 {
-	std::string to_check = stepParameters.FromInto;
+	InventoryType to_check = stepParameters.inventory;
 
-	if (to_check == "Wreck")
+	if (to_check == Wreck)
 	{
 		return true;
 	}
@@ -2357,11 +2365,11 @@ bool cMain::CheckTakePut(StepParameters& stepParameters)
 	string building = FindBuildingName(stepParameters.BuildingIndex);
 	if (check_input(building, chest_list))
 	{
-		stepParameters.FromInto = "Chest";
+		stepParameters.inventory = Chest;
 		return true;
 	}
 
-	if (to_check == "Fuel")
+	if (to_check == Fuel)
 	{
 		if (check_input(stepParameters.Item, fuel_list))
 		{
@@ -2374,7 +2382,7 @@ bool cMain::CheckTakePut(StepParameters& stepParameters)
 
 	if (building == "Lab")
 	{
-		if (to_check == "Input")
+		if (to_check == Input)
 		{
 			if (check_input(stepParameters.Item, science_packs))
 			{
@@ -2385,7 +2393,7 @@ bool cMain::CheckTakePut(StepParameters& stepParameters)
 			return false;
 
 		}
-		else if (to_check == "Modules")
+		else if (to_check == Modules)
 		{
 			if (check_input(stepParameters.Item, module_list))
 			{
@@ -2402,7 +2410,7 @@ bool cMain::CheckTakePut(StepParameters& stepParameters)
 
 	if (check_input(building, drills_list))
 	{
-		if (to_check == "Modules")
+		if (to_check == Modules)
 		{
 			if (check_input(stepParameters.Item, module_list))
 			{
@@ -2417,13 +2425,13 @@ bool cMain::CheckTakePut(StepParameters& stepParameters)
 		return false;
 	}
 
-	if (to_check == "Input")
+	if (to_check == Input)
 	{
 		// You might want to make some check that the input makes sense - but it might be pretty difficult to do in a good way
 		return true;
 	}
 
-	if (to_check == "Modules")
+	if (to_check == Modules)
 	{
 		if (check_input(stepParameters.Item, module_list))
 		{
@@ -2434,7 +2442,7 @@ bool cMain::CheckTakePut(StepParameters& stepParameters)
 		return false;
 	}
 
-	if (to_check == "Output")
+	if (to_check == Output)
 	{
 		// You might want to make some check that the input makes sense - but it might be pretty difficult to do in a good way
 		return true;
@@ -2519,7 +2527,7 @@ bool cMain::ValidateAllSteps()
 			case e_limit:
 			case e_put:
 			case e_take:
-				if (step.FromInto != "Wreck" && !BuildingExists(BuildingsSnapShot, buildingsInSnapShot, step))
+				if (step.inventory != Wreck && !BuildingExists(BuildingsSnapShot, buildingsInSnapShot, step))
 				{
 					string message = "Step " + to_string(i + 1) + " is not connected to a building. Ensure that the step is not placed before the build step.";
 					wxMessageBox(message, "Step not connected to building");

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -336,9 +336,9 @@ void cMain::MoveRow(wxGrid* grid, bool up)
 
 			BackgroundColorUpdate(grid, moveTo, ToStepType(grid->GetCellValue(moveTo, 0).ToStdString()));
 
-			if (StepGridData[row].Colour != "")
+			if (StepGridData[row].colour != wxNullColour)
 			{
-				wxColour colour = wxColour(StepGridData[row].Colour);
+				wxColour colour = StepGridData[row].colour;
 				grid->SetCellBackgroundColour(moveTo, 1, colour);
 				grid->SetCellBackgroundColour(moveTo, 2, colour);
 				grid->SetCellBackgroundColour(moveTo, 3, colour);
@@ -375,9 +375,9 @@ void cMain::MoveRow(wxGrid* grid, bool up)
 
 			BackgroundColorUpdate(grid, moveTo, ToStepType(grid->GetCellValue(moveTo, 0).ToStdString()));
 			
-			if (StepGridData[row].Colour != "")
+			if (StepGridData[row].colour != wxNullColour)
 			{
-				wxColour colour = wxColour(StepGridData[row].Colour);
+				wxColour colour = StepGridData[row].colour;
 				grid->SetCellBackgroundColour(moveTo, 1, colour);
 				grid->SetCellBackgroundColour(moveTo, 2, colour);
 				grid->SetCellBackgroundColour(moveTo, 3, colour);
@@ -1021,7 +1021,7 @@ void cMain::OnStepColourPickerColourChanged(wxColourPickerEvent& event)
 	{
 		for (int row = block.GetTopRow(); row <= block.GetBottomRow(); row++)
 		{
-			StepGridData.at(row).Colour = colour.GetAsString();
+			StepGridData.at(row).colour = colour;
 			grid_steps->SetCellBackgroundColour(row, 1, colour);
 			grid_steps->SetCellBackgroundColour(row, 2, colour);
 			grid_steps->SetCellBackgroundColour(row, 3, colour);
@@ -1081,9 +1081,9 @@ void cMain::SplitMultibuildStep(int row)
 
 		BackgroundColorUpdate(grid_steps, i, StepGridData[i].type);
 
-		if (StepGridData[i].Colour != "")
+		if (StepGridData[i].colour != wxNullColour)
 		{
-			wxColour colour = wxColour(StepGridData[i].Colour);
+			wxColour colour = StepGridData[i].colour;
 			grid_steps->SetCellBackgroundColour(i, 1, colour);
 			grid_steps->SetCellBackgroundColour(i, 2, colour);
 			grid_steps->SetCellBackgroundColour(i, 3, colour);
@@ -1412,9 +1412,9 @@ void cMain::PopulateStepGrid()
 
 		BackgroundColorUpdate(grid_steps, i, StepGridData[i].type);
 
-		if (StepGridData[i].Colour != "")
+		if (StepGridData[i].colour != wxNullColour)
 		{
-			wxColour colour = wxColour(StepGridData[i].Colour);
+			wxColour colour = StepGridData[i].colour;
 			grid_steps->SetCellBackgroundColour(i, 1, colour);
 			grid_steps->SetCellBackgroundColour(i, 2, colour);
 			grid_steps->SetCellBackgroundColour(i, 3, colour);

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -174,7 +174,7 @@ void cMain::HandleFocusMode(bool checked, bool changed)
 		int last_save = 0;
 		for (int i = StepGridData.size() - 1; i >= 0; i--)
 		{
-			if (StepGridData[i].StepEnum == StepType::e_save && !StepGridData[i].Modifiers.skip)
+			if (StepGridData[i].type == StepType::e_save && !StepGridData[i].Modifiers.skip)
 			{
 				last_save = i;
 				break;
@@ -473,7 +473,7 @@ bool cMain::ChangeRow(wxGrid* grid, StepParameters step)
 
 	PopulateGrid(grid, rowNum, &gridEntry);
 
-	BackgroundColorUpdate(grid, rowNum, step.StepEnum);
+	BackgroundColorUpdate(grid, rowNum, step.type);
 
 	no_changes = false;
 	return true;
@@ -570,7 +570,7 @@ vector<tuple<int, StepParameters>> cMain::AddStep(int row, StepParameters stepPa
 	};
 
 	string to_check;
-	switch (stepParameters.StepEnum)
+	switch (stepParameters.type)
 	{
 		case e_save:
 			UpdateStepGrid(row, &stepParameters);
@@ -594,8 +594,7 @@ vector<tuple<int, StepParameters>> cMain::AddStep(int row, StepParameters stepPa
 
 			to_check = stepParameters.Item;
 
-			stepParameters.StepEnum = e_put;
-			stepParameters.Step = StepNames[e_put];
+			stepParameters.type = e_put;
 			stepParameters.Amount = "1";
 			if (auto_put)
 			{
@@ -647,8 +646,7 @@ vector<tuple<int, StepParameters>> cMain::AddStep(int row, StepParameters stepPa
 
 				for (int i = 0; i < recipe.size(); i += 2)
 				{
-					stepParameters.StepEnum = e_put;
-					stepParameters.Step = StepNames[e_put];
+					stepParameters.type = e_put;
 					stepParameters.Amount = to_string(stoi(recipe[i + 1]) * multiplier);
 					stepParameters.Item = recipe[i];
 					stepParameters.FromInto = inventory_types.input;
@@ -662,7 +660,7 @@ vector<tuple<int, StepParameters>> cMain::AddStep(int row, StepParameters stepPa
 		}
 
 		default:			
-			type_panel->IncrementStateCounter(stepParameters.StepEnum);
+			type_panel->IncrementStateCounter(stepParameters.type);
 			UpdateStepGrid(row, &stepParameters); 
 			returnValue.push_back({row, stepParameters});
 			return returnValue;
@@ -680,7 +678,7 @@ void cMain::OnChangeStepClicked(wxCommandEvent& event)
 	}
 
 	int row = *rows.begin();
-	if (StepGridData[row].StepEnum == e_build)
+	if (StepGridData[row].type == e_build)
 	{
 		if (wxMessageBox("The row selected is a build step - are you sure you want to make this change?\nEnsure that you delete associated steps.", "The build step you are changing could be associated with future step", wxICON_WARNING | wxYES_NO, this) != wxYES)
 		{
@@ -728,13 +726,13 @@ vector< tuple<int, StepParameters>> cMain::ChangeStep(int row, StepParameters st
 {
 	vector< tuple<int, StepParameters>> change{};
 	
-	if (stepParameters.StepEnum == e_build)
+	if (stepParameters.type == e_build)
 	{
 		stepParameters.BuildingIndex = BuildingNameToType[stepParameters.Item];
 	}
-	else if (stepParameters.StepEnum != StepGridData[row].StepEnum)
+	else if (stepParameters.type != StepGridData[row].type)
 	{
-		type_panel->IncrementStateCounter(stepParameters.StepEnum);
+		type_panel->IncrementStateCounter(stepParameters.type);
 	}
 
 	GridEntry gridEntry = PrepareStepParametersForGrid(&stepParameters);
@@ -745,7 +743,7 @@ vector< tuple<int, StepParameters>> cMain::ChangeStep(int row, StepParameters st
 	StepGridData[row] = stepParameters;
 	PopulateGrid(grid_steps, row, &gridEntry);
 
-	BackgroundColorUpdate(grid_steps, row, stepParameters.StepEnum);
+	BackgroundColorUpdate(grid_steps, row, stepParameters.type);
 	HandleFocusMode(steps_focus_checkbox->IsChecked());
 	return change;
 }
@@ -817,7 +815,7 @@ vector< tuple<int, StepParameters>> cMain::DeleteSteps(wxArrayInt steps, bool au
 	for (const auto step : steps)
 	{
 		if (confirmed) break;
-		if (StepGridData[step].StepEnum == e_build)
+		if (StepGridData[step].type == e_build)
 		{
 			if (wxMessageBox("At least one of the rows selected is a build step - are you sure you want to delete the rows selected?\nEnsure that you delete associated steps.", 
 				"The build step(s) you are deleting could be associated with future step", 
@@ -831,7 +829,7 @@ vector< tuple<int, StepParameters>> cMain::DeleteSteps(wxArrayInt steps, bool au
 
 	for (const auto step : steps)
 	{
-		type_panel->IncrementStateCounter(StepGridData[step].StepEnum); break;
+		type_panel->IncrementStateCounter(StepGridData[step].type); break;
 	}
 
 	return_list.reserve(steps.size());
@@ -1081,7 +1079,7 @@ void cMain::SplitMultibuildStep(int row)
 
 		PopulateGrid(grid_steps, i, &gridEntry);
 
-		BackgroundColorUpdate(grid_steps, i, StepGridData[i].StepEnum);
+		BackgroundColorUpdate(grid_steps, i, StepGridData[i].type);
 
 		if (StepGridData[i].Colour != "")
 		{
@@ -1136,7 +1134,7 @@ void cMain::UpdateMapWithNewSteps(wxGrid* grid, wxComboBox* cmb, map<string, vec
 		{
 			GridTransfer(grid_steps, i, grid, moveTo);
 
-			BackgroundColorUpdate(grid, moveTo, StepGridData[i].StepEnum);
+			BackgroundColorUpdate(grid, moveTo, StepGridData[i].type);
 
 			auto it1 = steps.begin();
 			it1 += moveTo;
@@ -1412,7 +1410,7 @@ void cMain::PopulateStepGrid()
 
 		PopulateGrid(grid_steps, i, &gridEntry);
 
-		BackgroundColorUpdate(grid_steps, i, StepGridData[i].StepEnum);
+		BackgroundColorUpdate(grid_steps, i, StepGridData[i].type);
 
 		if (StepGridData[i].Colour != "")
 		{
@@ -1846,7 +1844,7 @@ StepParameters cMain::ExtractStepParameters()
 
 	auto stepParameters = StepParameters(spin_x->GetValue(), spin_y->GetValue());
 
-	stepParameters.Step = ExtractStep();
+	stepParameters.type = ToStepType(ExtractStep());
 	stepParameters.Amount = ExtractAmount();
 	stepParameters.Item = Capitalize(cmb_item->GetValue(), true);
 	stepParameters.FromInto = Capitalize(cmb_from_into->GetValue());
@@ -1869,7 +1867,7 @@ StepParameters cMain::ExtractStepParameters()
 		.all = modifier_all_checkbox->IsEnabled() && modifier_all_checkbox->GetValue(),
 	};
 
-	stepParameters.StepEnum = MapStepNameToStepType.find(stepParameters.Step)->second;
+	
 
 	return stepParameters;
 }
@@ -1928,12 +1926,12 @@ std::string cMain::ExtractAmount()
 GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 {
 	GridEntry gridEntry{
-		.Step = stepParameters->Step,
+		.Step = StepNames[stepParameters->type],
 		.Modifiers = stepParameters->Modifiers.ToString(),
 		.Comment = stepParameters->Comment,
 	};
 
-	switch (stepParameters->StepEnum)
+	switch (stepParameters->type)
 	{
 		case e_stop:
 			gridEntry.Comment = "";
@@ -2088,7 +2086,7 @@ void cMain::UpdateStepGrid(int row, StepParameters* stepParameters)
 	it1 += row;
 	StepGridData.insert(it1, *stepParameters);
 
-	BackgroundColorUpdate(grid_steps, row, stepParameters->StepEnum);
+	BackgroundColorUpdate(grid_steps, row, stepParameters->type);
 }
 
 int cMain::GenerateBuildingSnapShot(int end_row)
@@ -2097,7 +2095,7 @@ int cMain::GenerateBuildingSnapShot(int end_row)
 
 	for (int i = 0; i < end_row; i++)
 	{
-		switch (StepGridData[i].StepEnum)
+		switch (StepGridData[i].type)
 		{
 			case e_build:
 				buildingsInSnapShot = ProcessBuildStep(BuildingsSnapShot, buildingsInSnapShot, StepGridData[i]);
@@ -2138,7 +2136,7 @@ GridEntry cMain::ExtractGridEntry(wxGrid* grid, const int& row)
 bool cMain::ValidateStep(const int& row, StepParameters& stepParameters, bool validateBuildSteps)
 {
 	// Cases where an association with a building isn't needed
-	switch (stepParameters.StepEnum)
+	switch (stepParameters.type)
 	{
 		case e_walk:
 		case e_game_speed:
@@ -2176,7 +2174,7 @@ bool cMain::ValidateStep(const int& row, StepParameters& stepParameters, bool va
 	}
 
 	int amountOfBuildings = GenerateBuildingSnapShot(row);
-	switch (stepParameters.StepEnum)
+	switch (stepParameters.type)
 	{
 		case e_recipe:
 			if (!BuildingExists(BuildingsSnapShot, amountOfBuildings, stepParameters))
@@ -2450,7 +2448,7 @@ bool cMain::ExtraBuildingChecks(StepParameters& stepParameters)
 {
 	auto buildingName = FindBuildingName(stepParameters.BuildingIndex);
 
-	switch (stepParameters.StepEnum)
+	switch (stepParameters.type)
 	{
 		case e_limit:
 			if (check_input(buildingName, chest_list))
@@ -2492,7 +2490,7 @@ bool cMain::ValidateAllSteps()
 	{
 		StepParameters& step = StepGridData[i];
 
-		switch (step.StepEnum)
+		switch (step.type)
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType.find(step.Item)->second;
@@ -2563,7 +2561,7 @@ void cMain::NoOrderButtonHandle(bool force)
 	{
 		for (int row : rows)
 		{
-			StepType e = StepGridData.at(row).StepEnum;
+			StepType e = StepGridData.at(row).type;
 			if (! modifier_types.no_order.contains(e)) 
 			{
 				wxMessageBox(std::format("Step {} is unable to be assigned the no-order modifier. \n As it is of the type {}.", row + 1, StepNames[e]),
@@ -2577,7 +2575,7 @@ void cMain::NoOrderButtonHandle(bool force)
 	{
 		auto& step = StepGridData.at(row);
 		if (step.Modifiers.no_order == modifier_value && 
-			modifier_types.no_order.contains(step.StepEnum))
+			modifier_types.no_order.contains(step.type))
 		{
 			step.Modifiers.no_order = !modifier_value;
 			grid_steps->SetCellValue(row, 6, step.Modifiers.ToString());
@@ -2601,7 +2599,7 @@ void cMain::ForceButtonHandle(bool force)
 	{
 		for (int row : rows)
 		{
-			StepType e = StepGridData.at(row).StepEnum;
+			StepType e = StepGridData.at(row).type;
 			if (! modifier_types.force.contains(e))
 			{
 				wxMessageBox(std::format("Step {} is unable to be assigned the force modifier. \n As it is of the type {}.", row + 1, StepNames[e]),
@@ -2615,7 +2613,7 @@ void cMain::ForceButtonHandle(bool force)
 	{
 		auto& step = StepGridData.at(row);
 		if (step.Modifiers.force == modifier_value &&
-			modifier_types.force.contains(step.StepEnum))
+			modifier_types.force.contains(step.type))
 		{
 			step.Modifiers.force = !modifier_value;
 			grid_steps->SetCellValue(row, 6, step.Modifiers.ToString());

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1856,8 +1856,8 @@ StepParameters cMain::ExtractStepParameters()
 	stepParameters.Amount = ExtractAmount();
 	stepParameters.Item = Capitalize(cmb_item->GetValue(), true);
 	stepParameters.inventory = GetInventoryType(Capitalize(cmb_from_into->GetValue()));
-	stepParameters.Orientation = Capitalize(cmb_building_orientation->GetValue());
-	stepParameters.Direction = Capitalize(cmb_direction_to_build->GetValue());
+	stepParameters.orientation = Capitalize(cmb_building_orientation->GetValue());
+	stepParameters.Direction = MapStringToOrientation(cmb_direction_to_build->GetValue());
 	stepParameters.Size = spin_building_size->GetValue();
 	stepParameters.Buildings = spin_building_amount->GetValue();
 	stepParameters.priority.input = (Priority::Type) radio_input->GetSelection();
@@ -2000,7 +2000,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Amount = stepParameters->Amount;
 			gridEntry.Item = FindBuildingName(stepParameters->BuildingIndex);
-			gridEntry.DirectionToBuild = stepParameters->Direction;
+			gridEntry.DirectionToBuild = orientation_list[stepParameters->Direction];
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
 			stepParameters->Item = gridEntry.Item;
@@ -2010,8 +2010,8 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			gridEntry.X = std::to_string(stepParameters->X);
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Item = stepParameters->Item;
-			gridEntry.BuildingOrientation = stepParameters->Orientation;
-			gridEntry.DirectionToBuild = stepParameters->Direction;
+			gridEntry.BuildingOrientation = stepParameters->orientation;
+			gridEntry.DirectionToBuild = orientation_list[stepParameters->Direction];
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
 			break;
@@ -2023,7 +2023,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			gridEntry.Amount = stepParameters->Amount;
 			gridEntry.Item = stepParameters->Item;
 			gridEntry.Inventory = inventory_types_list[stepParameters->inventory];
-			gridEntry.DirectionToBuild = stepParameters->Direction;
+			gridEntry.DirectionToBuild = orientation_list[stepParameters->Direction];
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
 			break;
@@ -2037,18 +2037,18 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Amount = stepParameters->Amount;
 			gridEntry.Recipe = stepParameters->Item;
-			gridEntry.DirectionToBuild = stepParameters->Direction;
+			gridEntry.DirectionToBuild = orientation_list[stepParameters->Direction];
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
 			break;
 
 		case e_limit:
-			stepParameters->Orientation = "Chest";
+			stepParameters->orientation = "Chest";
 			gridEntry.X = std::to_string(stepParameters->X);
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Amount = stepParameters->Amount;
 			gridEntry.BuildingOrientation = "Chest";
-			gridEntry.DirectionToBuild = stepParameters->Direction;
+			gridEntry.DirectionToBuild = orientation_list[stepParameters->Direction];
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
 			break;
@@ -2057,7 +2057,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			gridEntry.X = std::to_string(stepParameters->X);
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Priority = stepParameters->priority.ToString();
-			gridEntry.DirectionToBuild = stepParameters->Direction;
+			gridEntry.DirectionToBuild = orientation_list[stepParameters->Direction];
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
 			break;
@@ -2073,7 +2073,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Amount = stepParameters->Amount;
 			gridEntry.Item = stepParameters->Item;
-			gridEntry.DirectionToBuild = stepParameters->Direction;
+			gridEntry.DirectionToBuild = orientation_list[stepParameters->Direction];
 			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
 			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
 			break;
@@ -2234,15 +2234,9 @@ bool cMain::IsValidBuildStep(StepParameters& stepParameters)
 		return false;
 	}
 
-	if (!check_input(stepParameters.Orientation, orientation_list))
+	if (!check_input(stepParameters.orientation, orientation_list))
 	{
 		wxMessageBox("The build direction is not valid - please try again", "Please use the build direction dropdown menu");
-		return false;
-	}
-
-	if (!check_input(stepParameters.Direction, orientation_list))
-	{
-		wxMessageBox("The direction to build is not valid - please try again", "Please use the direction to build dropdown menu");
 		return false;
 	}
 
@@ -2330,12 +2324,6 @@ bool cMain::IsValidPutTakeStep(StepParameters& stepParameters)
 {
 	if (!CheckTakePut(stepParameters))
 	{
-		return false;
-	}
-
-	if (!check_input(stepParameters.Direction, orientation_list))
-	{
-		wxMessageBox("The direction to build is not valid - please try again", "Please use the direction to build dropdown menu");
 		return false;
 	}
 
@@ -2502,7 +2490,7 @@ bool cMain::ValidateAllSteps()
 		{
 			case e_build:
 				step.BuildingIndex = BuildingNameToType.find(step.Item)->second;
-				step.OrientationEnum = MapStringToOrientation.find(step.Orientation)->second;
+				step.OrientationEnum = MapStringToOrientation(step.orientation);
 
 				buildingsInSnapShot = ProcessBuildStep(BuildingsSnapShot, buildingsInSnapShot, step);
 				break;

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -306,8 +306,9 @@ private:
 	void setup_paramters(const int parameters);
 	void SetupModifiers(StepType type);
 
+	void UpdateParametersChangeType(wxCommandEvent& event, StepType step);
 	void UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event, bool changeType = true);
-
+	
 	bool Save(string filename, bool save_as, bool set_last_location = true);
 	bool AutoSave();
 	bool SaveFile(bool save_as);


### PR DESCRIPTION
## Refactor of StepParameters

Many small changes to make StepParameters better aligned with my personal preference. Which in brief is to use specialized types for fields, which also avoids many situations where the field holds invalid data.

Given the large number of changes it might be easier to look through them per commit.

1. Renamed the field "StepEnum" to "type"
2. Renamed the field "FromInto" to "inventory"
3. Changed the field type `inventory` to `InventoryType`
4. Added aliases fields to GridEntry.h
5. Split `cMain::UpdateParameters()` into two functions
6. Fixed double clicking on step of the type `game_speed`
7. Moved initialization of StepParameter fields to the header file.
8. Changed the type Colour from `string` to `wxColour`, using wxNullColour as unset instead of empty string
9. Renamed the field `Orientation` to `orientation`, as that caused conflicts with the type Orientation
10. Changed the field type of `direction` from `string` to `Orientation`
11. Added new file for shared string functions

### Shared string functions
This change is somewhat half baked, as i didn't move functions from functions.h to it

However it is also necessary, as the inclusion of our own base types such as Orientation, means that functions can't be included to improve Orientation.h as that gives compiler loops.

### Aliases
The uses of reference fields allows us to have alias field. It works a bit like pointers that can't be re-pointed. Where any change to either the referenced or the referencing field is reflected either place.

### Follow up
I still have a few changes before i am satisfied with StepParameters. 

- I want it renamed to Step, but changing that creates so many changes that it is impossible to see what else has changed
- The field Amount should be a number type
- The field Item should be something more appropriate
- The field orientation should be of the Orientation type 