### PR TITLE
Fix that mining takes 1 additional tick when the step is not ended by an event.

### DIFF
--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -1525,7 +1525,7 @@ local function handle_ontick()
 			ticks_mining = ticks_mining + 1
 
 			if ticks_mining >= duration then
-				player.mining_state = {mining = false, position = steps[step][3]}
+				if LEGACY_MINING then player.mining_state = {mining = false, position = steps[step][3]} end
 				change_step(1)
 				step_executed = true
 				mining = 0
@@ -1560,7 +1560,7 @@ local function handle_ontick()
 			ticks_mining = ticks_mining + 1
 
 			if ticks_mining >= duration then
-				player.mining_state = {mining = false, position = steps[step][3]}
+				if LEGACY_MINING then player.mining_state = {mining = false, position = steps[step][3]} end
 				change_step(1)
 				mining = 0
 				ticks_mining = 0
@@ -1864,7 +1864,7 @@ script.on_event(defines.events.on_player_mined_entity, function(event)
 	end
 
 	--change step when tas is running and the current step is mining step
-	if run and steps[step] and steps[step][2] and steps[step][2] == "mine" then
+	if run and steps[step] and steps[step][2] and steps[step][2] == "mine" and (LEGACY_MINING or ticks_mining > 1) then
 		change_step(1)
 	end
 

--- a/src/Data/utils.h
+++ b/src/Data/utils.h
@@ -1121,6 +1121,16 @@ struct log_config
 	}
 };
 
+// Additional script generation configurations
+struct generate_config
+{
+	bool legacy_mining = false;
+	std::string to_string()
+	{
+		return std::to_string(legacy_mining) + ";";
+	}
+};
+
 struct WarningsStatesCounters
 {
 	int never_idle = 0;

--- a/src/Factorio-TAS-Generator.vcxproj.filters
+++ b/src/Factorio-TAS-Generator.vcxproj.filters
@@ -15,12 +15,14 @@
     <ClCompile Include="CommandStack.cpp" />
     <ClCompile Include="SteptypeColour.cpp" />
     <ClCompile Include="Shared functions\Functions.cpp" />
-    <ClCompile Include="Structures\StepParameters.cpp" />
     <ClCompile Include="TAS save file\OpenTas.cpp" />
     <ClCompile Include="TAS save file\SaveTas.cpp" />
     <ClCompile Include="TemplatePage.cpp" />
     <ClCompile Include="WalkPanel.cpp" />
     <ClCompile Include="Shared functions\StringFunctions.cpp" />
+    <ClCompile Include="Structures\StepParameters.cpp">
+      <Filter>Structs</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cApp.h" />
@@ -43,22 +45,40 @@
     </ClInclude>
     <ClInclude Include="CommandStack.h" />
     <ClInclude Include="SteptypeColour.h" />
-    <ClInclude Include="Data\BuildingNames.h" />
-    <ClInclude Include="Data\Inventory.h" />
     <ClInclude Include="Data\utils.h" />
     <ClInclude Include="Shared functions\Functions.h" />
-    <ClInclude Include="Structures\Building.h" />
-    <ClInclude Include="Structures\GridEntry.h" />
-    <ClInclude Include="Structures\Orientation.h" />
-    <ClInclude Include="Structures\ParameterChoices.h" />
-    <ClInclude Include="Structures\Priority.h" />
     <ClInclude Include="Structures\StepModifiers.h" />
-    <ClInclude Include="Structures\StepParameters.h" />
-    <ClInclude Include="Structures\StepType.h" />
     <ClInclude Include="TAS save file\OpenTas.h" />
     <ClInclude Include="TAS save file\SaveTas.h" />
     <ClInclude Include="TAS save file\TasFileConstants.h" />
     <ClInclude Include="Shared functions\StringFunctions.h" />
+    <ClInclude Include="Structures\Building.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
+    <ClInclude Include="Data\BuildingNames.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
+    <ClInclude Include="Structures\Priority.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
+    <ClInclude Include="Structures\ParameterChoices.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
+    <ClInclude Include="Structures\Orientation.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
+    <ClInclude Include="Data\Inventory.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
+    <ClInclude Include="Structures\GridEntry.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
+    <ClInclude Include="Structures\StepParameters.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
+    <ClInclude Include="Structures\StepType.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\Lua Files\control.lua">
@@ -70,7 +90,9 @@
     <CopyFileToFolders Include="..\Lua Files\settings.lua">
       <Filter>lua</Filter>
     </CopyFileToFolders>
-    <CopyFileToFolders Include="..\Lua Files\goals.lua" />
+    <CopyFileToFolders Include="..\Lua Files\goals.lua">
+      <Filter>lua</Filter>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Structs">

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -1004,6 +1004,24 @@
                         <event name="OnMenuSelection">OnMenuAutoCloseSaveAsClicked</event>
                     </object>
                 </object>
+                <object class="wxMenu" expanded="1">
+                    <property name="label">Legacy</property>
+                    <property name="name">menu_legacy</property>
+                    <property name="permission">protected</property>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_CHECK</property>
+                        <property name="label">Legacy mining</property>
+                        <property name="name">legacy_mining</property>
+                        <property name="permission">protected</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                    </object>
+                </object>
             </object>
             <object class="wxPanel" expanded="1">
                 <property name="BottomDockable">0</property>

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -298,6 +298,12 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 
 	main_menubar->Append( menu_auto_close, wxT("Auto-close") );
 
+	menu_legacy = new wxMenu();
+	legacy_mining = new wxMenuItem( menu_legacy, wxID_ANY, wxString( wxT("Legacy mining") ) , wxEmptyString, wxITEM_CHECK );
+	menu_legacy->Append( legacy_mining );
+
+	main_menubar->Append( menu_legacy, wxT("Legacy") );
+
 	this->SetMenuBar( main_menubar );
 
 	detail_panel = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -67,6 +67,8 @@ class GUI_Base : public wxFrame
 		wxMenuItem* logging_tech;
 		wxMenuItem* logging_comment;
 		wxMenu* menu_auto_close;
+		wxMenu* menu_legacy;
+		wxMenuItem* legacy_mining;
 		wxPanel* detail_panel;
 		wxStaticText* label_x_cord;
 		wxSpinCtrlDouble* spin_x;

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -64,7 +64,7 @@ inline const char* const bool_to_string(bool b)
 	return b ? "true" : "false";
 }
 
-void GenerateScript::AddVariableFile(string& folder_location, string& goal, log_config logconfig)
+void GenerateScript::AddVariableFile(string& folder_location, string& goal, log_config logconfig, generate_config generateconfig)
 {
 	using std::endl;
 	std::ofstream saver;
@@ -78,6 +78,7 @@ void GenerateScript::AddVariableFile(string& folder_location, string& goal, log_
 	saver << "PRINT_SAVEGAME" << " = " << bool_to_string(logconfig.savegame) << endl;
 	saver << "PRINT_TECH" << " = " << bool_to_string(logconfig.tech) << endl;
 	saver << "PRINT_COMMENT" << " = " << bool_to_string(logconfig.comment) << endl << endl;
+	saver << "LEGACY_MINING" << " = " << bool_to_string(generateconfig.legacy_mining) << endl << endl;
 
 	saver << "local tas_generator = {" << endl;
 	saver << "\t" << "name = \"" << generator_thumbprint.name << "\"," << endl;
@@ -130,7 +131,7 @@ void GenerateScript::PaintWalkStep(string step, bool straight, bool diagonal)
 	grid_steps->SetCellBackgroundColour(row, 10, straight ? "#AFBFBF" : diagonal ? "#BF9FBF" : "#FFFFFF");
 }
 
-void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, string goal, log_config logconfig)
+void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, string goal, log_config logconfig, generate_config generateconfig)
 {
 	this->name = folder_location.substr(folder_location.find_last_of('\\') + 1);
 	reset();
@@ -412,7 +413,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 	fs::copy_file(pre_fix + "settings.lua", folder_location + "\\settings.lua", fs::copy_options::update_existing);
 	fs::copy_file(pre_fix + "goals.lua", folder_location + "\\goals.lua", fs::copy_options::update_existing);
 
-	AddVariableFile(folder_location, goal, logconfig);
+	AddVariableFile(folder_location, goal, logconfig, generateconfig);
 	AddInfoFile(folder_location);
 
 	std::ofstream saver;

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -29,7 +29,7 @@ class GenerateScript
 {
 public:
 	GenerateScript(wxGrid* grid_steps);
-	void generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, string goal, log_config logconfig);
+	void generate(wxWindow* parent, DialogProgressBar* dialog_progress_bar, vector<StepParameters> steps, string& folder_location, bool auto_close, string goal, log_config logconfig, generate_config generateconfig);
 	const std::string currentDateTime(); // Get current date/time, format is YYYY-MM-DD.HH:mm:ss
 
 private:
@@ -70,7 +70,7 @@ private:
 	string EndSteps();
 	void UnexpectedError(DialogProgressBar* dialog_progress_bar, int error_step);
 
-	void AddVariableFile(string& folder_location, string& goal, log_config logconfig);
+	void AddVariableFile(string& folder_location, string& goal, log_config logconfig, generate_config generateconfig);
 	void AddInfoFile(string& folder_location);
 
 	void PaintWarningStateChanged(string step, int counter);

--- a/src/TAS save file/OpenTas.cpp
+++ b/src/TAS save file/OpenTas.cpp
@@ -72,6 +72,9 @@ open_file_return_data* OpenTas::Open(DialogProgressBar* dialog_progress_bar, std
 	if (!extract_log_config(file))
 		return_data.success = false;
 
+	if (!extract_generate_config(file))
+		return_data.success = false;
+
 	return &return_data;
 }
 
@@ -591,6 +594,26 @@ bool OpenTas::extract_auto_put(std::ifstream& file)
 
 	return_data.auto_put_recipe = segments[1] == "true";
 
+	return true;
+}
+
+bool OpenTas::extract_generate_config(std::ifstream& file)
+{
+	if (!update_segment(file)) // logconfig doesn't exist so default
+	{
+		return_data.generateConfig = {
+			.legacy_mining = false,
+		};
+		return true;
+	}
+	else if (segments[0] != generate_indicator)
+	{
+		return false;
+	}
+	size_t s = segments.size();
+	return_data.generateConfig = {
+		.legacy_mining = s < 2 || segments[1] == "1" ? true : false,
+	};
 	return true;
 }
 

--- a/src/TAS save file/OpenTas.h
+++ b/src/TAS save file/OpenTas.h
@@ -48,6 +48,7 @@ struct open_file_return_data
 	bool auto_put_recipe = false;
 
 	log_config logconfig;
+	generate_config generateConfig;
 	WarningsStatesCounters warnings_states_counters;
 };
 
@@ -84,6 +85,7 @@ private:
 	bool extract_script_location(std::ifstream& file);
 	bool extract_auto_close(std::ifstream& file);
 	bool extract_auto_put(std::ifstream& file);
+	bool extract_generate_config(std::ifstream& file);
 	bool extract_log_config(std::ifstream & file);
 
 	bool update_segment(std::ifstream& file);

--- a/src/TAS save file/SaveTas.cpp
+++ b/src/TAS save file/SaveTas.cpp
@@ -15,6 +15,7 @@ bool SaveTas::Save(
 	string folder_location_generate,
 	string goal,
 	log_config logconfig,
+	generate_config generateconfig,
 	wxGridBlockCoordsVector selected_rows,
 	bool set_last_location)
 {
@@ -102,7 +103,8 @@ bool SaveTas::Save(
 	for (auto p : selected_rows) 
 		s_selected_rows += to_string(p.GetTopRow()) + ";" + to_string(p.GetBottomRow()) + ";";
 	myfile << "selected rows;" << s_selected_rows << std::endl;
-	myfile << logging_indicator << ";" << logconfig.to_string();
+	myfile << logging_indicator << ";" << logconfig.to_string() << std::endl;
+	myfile << generate_indicator << ";" << generateconfig.to_string();
 
 	myfile.close();
 

--- a/src/TAS save file/SaveTas.h
+++ b/src/TAS save file/SaveTas.h
@@ -33,6 +33,7 @@ public:
 		string folder_location_generate,
 		string goal,
 		log_config logconfig,
+		generate_config generateconfig,
 		wxGridBlockCoordsVector selected_rows,
 		bool set_last_location = true
 	);

--- a/src/TAS save file/TasFileConstants.h
+++ b/src/TAS save file/TasFileConstants.h
@@ -25,6 +25,7 @@ static const string code_file_indicator = "Step folder location:";
 static const string auto_close_indicator = "Auto close settings:";
 static const string auto_put_indicator = "Auto put settings:";
 static const string logging_indicator = "logging";
+static const string generate_indicator = "generate settings";
 
 static const string auto_close_generate_script_text = "Generate Script";
 static const string auto_close_open_text = "Open";

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1263,6 +1263,9 @@ void cMain::Open(std::ifstream * file)
 	logmenu[2]->Check(logconfig.comment);
 	logmenu[4 + (int)logconfig.level]->Check();
 
+	generate_config generateConfig = result->generateConfig;
+	legacy_mining->Check(generateConfig.legacy_mining);
+
 	menu_auto_close->GetMenuItems()[0]->Check(result->auto_close_generate_script);
 	auto_close_generate_script = result->auto_close_generate_script;
 
@@ -1478,11 +1481,19 @@ log_config cMain::GetLogConfig()
 	return logconfig;
 }
 
+generate_config cMain::GetGenerateConfig()
+{
+	return generate_config{
+		.legacy_mining = legacy_mining->IsChecked(),
+	};
+}
+
 void cMain::OnGenerateScript(wxCommandEvent& event)
 {
 	string goal = GetGoalConfig();
 
 	log_config logconfig = GetLogConfig();
+	generate_config generateconfig = GetGenerateConfig();
 
 	if (!ValidateAllSteps())
 	{
@@ -1490,7 +1501,7 @@ void cMain::OnGenerateScript(wxCommandEvent& event)
 	};
 
 	GenerateScript generate_script(grid_steps);
-	generate_script.generate(this, dialog_progress_bar, StepGridData, generate_code_folder_location, auto_close_generate_script, goal, logconfig);
+	generate_script.generate(this, dialog_progress_bar, StepGridData, generate_code_folder_location, auto_close_generate_script, goal, logconfig, generateconfig);
 
 	grid_steps->Update();
 
@@ -1799,6 +1810,7 @@ bool cMain::Save(string filename, bool save_as, bool set_last_location)
 		generate_code_folder_location,
 		GetGoalConfig(),
 		GetLogConfig(),
+		GetGenerateConfig(),
 		grid_steps->GetSelectedRowBlocks(),
 		set_last_location);
 }

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -66,6 +66,7 @@ protected:
 	void OnChooseLocation(wxCommandEvent& event);
 	std::string GetGoalConfig();
 	log_config GetLogConfig();
+	generate_config GetGenerateConfig();
 	void OnGenerateScript(wxCommandEvent& event);
 
 	// Step types menu


### PR DESCRIPTION
I am somewhat curious why this line was ever added.

The game will automatically disable mining in the next tick.

_______________________________

So it turned out that the line was there to prevent skipping the next step.