### PR TITLE
Refactor open tas

### DIFF
--- a/src/TAS save file/OpenTas.h
+++ b/src/TAS save file/OpenTas.h
@@ -37,27 +37,37 @@ struct open_file_return_data
 
 	wxGridBlockCoordsVector selected_rows;
 
-	bool auto_close_generate_script = false;
-	bool auto_close_open = false;
-	bool auto_close_save = false;
-	bool auto_close_save_as = false;
+	struct
+	{
+		bool generate_script = false,
+			open = false,
+			save = false,
+			save_as = false;
+	} auto_close;
 
-	bool auto_put_furnace = false;
-	bool auto_put_burner = false;
-	bool auto_put_lab = false;
-	bool auto_put_recipe = false;
+	struct
+	{
+		bool furnace = false,
+			burner = false,
+			lab = false,
+			recipe = false;
+	} auto_put;
 
 	log_config logconfig;
 	generate_config generateConfig;
+
 	WarningsStatesCounters warnings_states_counters;
 };
 
-enum Category
+struct OpenTAS
 {
-	Invalid,
-	Group,
-	Template
-};
+	enum Category
+	{
+		Invalid,
+		Group,
+		Template
+	};
+} ;
 
 class OpenTas
 {
@@ -78,7 +88,7 @@ private:
 
 	bool extract_total_steps(std::ifstream& file);
 	bool extract_goal(std::ifstream& file);
-	Category extract_steps(std::ifstream& file, DialogProgressBar* dialog_progress_bar);
+	OpenTAS::Category extract_steps(std::ifstream& file, DialogProgressBar* dialog_progress_bar);
 	bool extract_groups(std::ifstream& file, DialogProgressBar* dialog_progress_bar);
 	bool extract_templates(std::ifstream& file, DialogProgressBar* dialog_progress_bar);
 	bool extract_save_location(std::ifstream& file);
@@ -88,6 +98,6 @@ private:
 	bool extract_generate_config(std::ifstream& file);
 	bool extract_log_config(std::ifstream & file);
 
+	Step ReadStep(const size_t, int&, std::vector<string>::iterator);
 	bool update_segment(std::ifstream& file);
 };
-

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1271,22 +1271,22 @@ void cMain::Open(std::ifstream * file)
 	generate_config generateConfig = result->generateConfig;
 	legacy_mining->Check(generateConfig.legacy_mining);
 
-	menu_auto_close->GetMenuItems()[0]->Check(result->auto_close_generate_script);
-	auto_close_generate_script = result->auto_close_generate_script;
+	menu_auto_close->GetMenuItems()[0]->Check(result->auto_close.generate_script);
+	auto_close_generate_script = result->auto_close.generate_script;
 
-	menu_auto_close->GetMenuItems()[1]->Check(result->auto_close_open);
-	auto_close_open = result->auto_close_open;
+	menu_auto_close->GetMenuItems()[1]->Check(result->auto_close.open);
+	auto_close_open = result->auto_close.open;
 
-	menu_auto_close->GetMenuItems()[2]->Check(result->auto_close_save);
-	auto_close_save = result->auto_close_save;
+	menu_auto_close->GetMenuItems()[2]->Check(result->auto_close.save);
+	auto_close_save = result->auto_close.save;
 
-	menu_auto_close->GetMenuItems()[3]->Check(result->auto_close_save_as);
-	auto_close_save_as = result->auto_close_save_as;
+	menu_auto_close->GetMenuItems()[3]->Check(result->auto_close.save_as);
+	auto_close_save_as = result->auto_close.save_as;
 
-	check_furnace->SetValue(result->auto_put_furnace);
-	check_burner->SetValue(result->auto_put_burner);
-	check_lab->SetValue(result->auto_put_lab);
-	check_recipe->SetValue(result->auto_put_recipe);
+	check_furnace->SetValue(result->auto_put.furnace);
+	check_burner->SetValue(result->auto_put.burner);
+	check_lab->SetValue(result->auto_put.lab);
+	check_recipe->SetValue(result->auto_put.recipe);
 
 	PopulateStepGrid();
 


### PR DESCRIPTION
### Refactor OpenTas

- Moved enum **Category** into a Struct, to prevent collisions.
- Moved open_file_return_data::auto_close fields into a struct.
- Moved open_file_return_data::auto_put fields into a struct.
- Added method **ReadStep** to consolidate extract step data code from groups, templates, & steps.

__________

Not really happy with the name ReadStep, however i am proud of the technique of using a vector iterator to reuse the same code for steps, templates (and groups).