### PR TITLE
Add editor to steps grid

### DIFF
--- a/src/Data/utils.h
+++ b/src/Data/utils.h
@@ -458,7 +458,7 @@ static const map<string, vector<float>> old_building_size_list = {
 	{"Wreck", {1, 1}}
 };
 
-static const std::vector<std::string> handcrafted_list = {
+static std::vector<std::string> handcrafted_list = {
 	"Accumulator",
 	"Wooden chest",
 	"Iron chest",

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -10101,7 +10101,7 @@
                                             <property name="drag_col_size">1</property>
                                             <property name="drag_grid_size">0</property>
                                             <property name="drag_row_size">0</property>
-                                            <property name="editing">0</property>
+                                            <property name="editing">1</property>
                                             <property name="enabled">1</property>
                                             <property name="fg"></property>
                                             <property name="floatable">1</property>
@@ -10145,8 +10145,11 @@
                                             <property name="window_extra_style"></property>
                                             <property name="window_name"></property>
                                             <property name="window_style"></property>
+                                            <event name="OnGridCellChange">OnStepsGridCellChange</event>
                                             <event name="OnGridCellLeftDClick">OnStepsGridDoubleLeftClick</event>
                                             <event name="OnGridCellRightDClick">OnStepsGridDoubleRightClick</event>
+                                            <event name="OnGridEditorHidden">OnStepsGridEditorHidden</event>
+                                            <event name="OnGridEditorShown">OnStepsGridEditorShown</event>
                                             <event name="OnGridLabelLeftDClick">OnStepsGridDoubleLeftClick</event>
                                             <event name="OnGridLabelRightDClick">OnStepsGridDoubleRightClick</event>
                                             <event name="OnGridRangeSelect">OnStepsGridRangeSelect</event>

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -1428,7 +1428,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 
 	// Grid
 	grid_steps->CreateGrid( 0, 11 );
-	grid_steps->EnableEditing( false );
+	grid_steps->EnableEditing( true );
 	grid_steps->EnableGridLines( true );
 	grid_steps->EnableDragGridSize( false );
 	grid_steps->SetMargins( 0, 0 );
@@ -1721,8 +1721,11 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	btn_move_up->Connect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GUI_Base::OnMoveUpFiveClicked ), NULL, this );
 	btn_move_down->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnMoveDownClicked ), NULL, this );
 	btn_move_down->Connect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GUI_Base::OnMoveDownFiveClicked ), NULL, this );
+	grid_steps->Connect( wxEVT_GRID_CELL_CHANGED, wxGridEventHandler( GUI_Base::OnStepsGridCellChange ), NULL, this );
 	grid_steps->Connect( wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler( GUI_Base::OnStepsGridDoubleLeftClick ), NULL, this );
 	grid_steps->Connect( wxEVT_GRID_CELL_RIGHT_DCLICK, wxGridEventHandler( GUI_Base::OnStepsGridDoubleRightClick ), NULL, this );
+	grid_steps->Connect( wxEVT_GRID_EDITOR_HIDDEN, wxGridEventHandler( GUI_Base::OnStepsGridEditorHidden ), NULL, this );
+	grid_steps->Connect( wxEVT_GRID_EDITOR_SHOWN, wxGridEventHandler( GUI_Base::OnStepsGridEditorShown ), NULL, this );
 	grid_steps->Connect( wxEVT_GRID_LABEL_LEFT_DCLICK, wxGridEventHandler( GUI_Base::OnStepsGridDoubleLeftClick ), NULL, this );
 	grid_steps->Connect( wxEVT_GRID_LABEL_RIGHT_DCLICK, wxGridEventHandler( GUI_Base::OnStepsGridDoubleRightClick ), NULL, this );
 	grid_steps->Connect( wxEVT_GRID_RANGE_SELECT, wxGridRangeSelectEventHandler( GUI_Base::OnStepsGridRangeSelect ), NULL, this );
@@ -1815,8 +1818,11 @@ GUI_Base::~GUI_Base()
 	btn_move_up->Disconnect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GUI_Base::OnMoveUpFiveClicked ), NULL, this );
 	btn_move_down->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnMoveDownClicked ), NULL, this );
 	btn_move_down->Disconnect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GUI_Base::OnMoveDownFiveClicked ), NULL, this );
+	grid_steps->Disconnect( wxEVT_GRID_CELL_CHANGED, wxGridEventHandler( GUI_Base::OnStepsGridCellChange ), NULL, this );
 	grid_steps->Disconnect( wxEVT_GRID_CELL_LEFT_DCLICK, wxGridEventHandler( GUI_Base::OnStepsGridDoubleLeftClick ), NULL, this );
 	grid_steps->Disconnect( wxEVT_GRID_CELL_RIGHT_DCLICK, wxGridEventHandler( GUI_Base::OnStepsGridDoubleRightClick ), NULL, this );
+	grid_steps->Disconnect( wxEVT_GRID_EDITOR_HIDDEN, wxGridEventHandler( GUI_Base::OnStepsGridEditorHidden ), NULL, this );
+	grid_steps->Disconnect( wxEVT_GRID_EDITOR_SHOWN, wxGridEventHandler( GUI_Base::OnStepsGridEditorShown ), NULL, this );
 	grid_steps->Disconnect( wxEVT_GRID_LABEL_LEFT_DCLICK, wxGridEventHandler( GUI_Base::OnStepsGridDoubleLeftClick ), NULL, this );
 	grid_steps->Disconnect( wxEVT_GRID_LABEL_RIGHT_DCLICK, wxGridEventHandler( GUI_Base::OnStepsGridDoubleRightClick ), NULL, this );
 	grid_steps->Disconnect( wxEVT_GRID_RANGE_SELECT, wxGridRangeSelectEventHandler( GUI_Base::OnStepsGridRangeSelect ), NULL, this );

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -345,8 +345,11 @@ class GUI_Base : public wxFrame
 		virtual void OnMoveUpFiveClicked( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnMoveDownClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMoveDownFiveClicked( wxMouseEvent& event ) { event.Skip(); }
+		virtual void OnStepsGridCellChange( wxGridEvent& event ) { event.Skip(); }
 		virtual void OnStepsGridDoubleLeftClick( wxGridEvent& event ) { event.Skip(); }
 		virtual void OnStepsGridDoubleRightClick( wxGridEvent& event ) { event.Skip(); }
+		virtual void OnStepsGridEditorHidden( wxGridEvent& event ) { event.Skip(); }
+		virtual void OnStepsGridEditorShown( wxGridEvent& event ) { event.Skip(); }
 		virtual void OnStepsGridRangeSelect( wxGridRangeSelectEvent& event ) { event.Skip(); }
 		virtual void OnImportStepsIntoStepsIndexBtnClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnImportStepsIntoStepsIndexBtnRight( wxMouseEvent& event ) { event.Skip(); }

--- a/src/Structures/Orientation.h
+++ b/src/Structures/Orientation.h
@@ -76,3 +76,17 @@ Orientation static MapStringToOrientation(const wxString str)
 {
 	return MapStringToOrientation(str.ToStdString());
 }
+
+bool static MapStringToOrientation(const std::string str, Orientation& orientation)
+{
+	auto mapped = string_to_orientation.find(str);
+	if (mapped == string_to_orientation.end())
+		return false;
+	orientation = mapped->second;
+	return true;
+}
+
+bool static MapStringToOrientation(const wxString str, Orientation& orientation)
+{
+	return MapStringToOrientation(str.ToStdString(), orientation);
+}

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -210,6 +210,10 @@ protected:
 	void OnStepsFocusCheckbox(wxCommandEvent & event);
 	void HandleFocusMode(bool checked, bool changed = false);
 
+	void OnStepsGridCellChange(wxGridEvent& event);
+	void OnStepsGridEditorShown(wxGridEvent& event);
+	void OnStepsGridEditorHidden(wxGridEvent& event);
+
 	// Template
 	void OnNewTemplateClicked(wxCommandEvent& event);
 	void OnDeleteTemplateClicked(wxCommandEvent& event);


### PR DESCRIPTION
### Add editor to steps grid
- Enabled editor on steps grid
- Added method to handle editing on steps grid
- Added method to disallow editing of step type
- Set format amount=any, size=number, buildings=number 
- Added orientation from string with error output
- Changed handcrafted_list to modifiable, to make it fit into item validation.

This change enables in place editor to each field in steps grid, except the step type column.
There is "some" input validation on the editor, it might not be totally correct but it should be close enough for non-malicious users.
If validation fails, then the field reverts back. (i tried adding an error sound, but failed).
Undo/redo is also implemented for it.