### PR TITLE
Feature Re-order

### DIFF
--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -1402,6 +1402,7 @@ local original_warning = Warning
 local function load_StepBlock()
 	if global.step_block or not steps[step].no_order then return end
 	global.step_block = {}
+	global.executed_step_block = {finalized = false}
 	Debug("entering step block")
 	Warning = function ()
 		--override Warning with a function that does nothing
@@ -1430,8 +1431,9 @@ local function execute_StepBlock()
 		if _success then
 			Debug(string.format("Executed %d - Type: %s, Step: %d", _step[1][1], _step[2]:gsub("^%l", string.upper), _step_index), true)
 			table.remove(global.step_block, i)
-			if i == 1 then
-				local fast_change_step = _step_index - step
+			table.insert(global.executed_step_block, _step)
+			if i == 1 and #global.step_block > 1 then
+				local fast_change_step = global.step_block[1] - step
 				change_step(fast_change_step)
 				global.step_block_info.steps_left = global.step_block_info.steps_left - fast_change_step
 			end
@@ -1442,6 +1444,7 @@ local function execute_StepBlock()
 		change_step(global.step_block_info.steps_left)
 		global.step_block = nil
 		global.step_block_info = nil
+		global.executed_step_block.finalized = true
 		Warning = original_warning
 		Debug("Ending step block")
 	elseif (game.tick - global.step_block_info.start_tick) > (15 * global.step_block_info.total_steps) then
@@ -2106,6 +2109,62 @@ local function skip(data)
 	end
 end
 
+local function re_order_step_block()
+	if not global.executed_step_block or not global.executed_step_block.finalized then
+		game.print("No order block is not valid for export")
+		return
+	end
+
+	local function add_title_bar(frame, title)
+        local title_bar = frame.add{ type = "flow", direction = "horizontal", name = "title_bar", }
+        title_bar.drag_target = frame
+        title_bar.add{ type = "sprite", sprite = "tas_helper_icon"}
+        title_bar.add{ type = "label", style = "frame_title", caption = title, ignored_by_interaction = true, }
+        title_bar.add{ type = "empty-widget", style = "tas_helper_title_bar_draggable_space", ignored_by_interaction = true, }
+        local frame_close_button = title_bar.add{ type = "sprite-button", style = "frame_action_button", sprite = "utility/close_white", hovered_sprite = "utility/close_black", clicked_sprite = "utility/close_black", }
+        return frame_close_button
+    end
+
+	local screen = player.gui.screen
+	local export_frame = screen.add{ type = "frame", direction = "vertical", visible = false, }
+    export_frame.force_auto_center()
+
+	local export_frame_close_button = add_title_bar(export_frame, "Export re-order to FTG")
+	
+    local export_task_list_label = export_frame.add{ type = "label", style = "caption_label", caption = "", tooltip = "Copy these into the FTGs re-order panel", }
+    export_task_list_label.style.top_margin = 6
+
+    local export_textbox = export_frame.add{ type = "text-box", style = "tas_helper_export_textbox", } -- local style
+    export_textbox.read_only = true
+
+	local lines = {}
+    for i, _step in ipairs(global.executed_step_block) do
+		local s = _step and string.format("%d;%d;%d;",i,_step[1][1], _step[1][2]) or nil
+		if s then
+            table.insert(lines, s)
+        end
+	end
+	export_textbox.text = table.concat(lines, "\n")
+	export_textbox.focus()
+	export_textbox.select_all()
+
+	export_frame.visible = true
+    export_frame.bring_to_front()
+    player.opened = export_frame
+
+	script.on_event(defines.events.on_gui_click, function(event)
+		local element = event.element
+		local _player = game.get_player(event.player_index)
+		if element == export_frame_close_button then
+			export_frame.visible = false
+			if _player.opened == export_frame then
+				_player.opened = nil
+			end
+		end
+	end)
+end
+
+commands.add_command("reorder", nil, re_order_step_block)
 commands.add_command("release", nil, release)
 commands.add_command("resume", nil, resume)
 commands.add_command("skip", nil, skip)

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -10794,6 +10794,405 @@
                         </object>
                     </object>
                 </object>
+                <object class="auinotebookpage" expanded="1">
+                    <property name="bitmap"></property>
+                    <property name="label">Reorder</property>
+                    <property name="select">0</property>
+                    <object class="wxPanel" expanded="1">
+                        <property name="BottomDockable">1</property>
+                        <property name="LeftDockable">1</property>
+                        <property name="RightDockable">1</property>
+                        <property name="TopDockable">1</property>
+                        <property name="aui_layer"></property>
+                        <property name="aui_name">Re-order</property>
+                        <property name="aui_position"></property>
+                        <property name="aui_row"></property>
+                        <property name="best_size"></property>
+                        <property name="bg"></property>
+                        <property name="caption">Re-order panel for straightening out no-order blocks</property>
+                        <property name="caption_visible">1</property>
+                        <property name="center_pane">0</property>
+                        <property name="close_button">1</property>
+                        <property name="context_help"></property>
+                        <property name="context_menu">1</property>
+                        <property name="default_pane">0</property>
+                        <property name="dock">Dock</property>
+                        <property name="dock_fixed">0</property>
+                        <property name="docking">Left</property>
+                        <property name="drag_accept_files">0</property>
+                        <property name="enabled">1</property>
+                        <property name="fg"></property>
+                        <property name="floatable">1</property>
+                        <property name="font"></property>
+                        <property name="gripper">0</property>
+                        <property name="hidden">0</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="max_size"></property>
+                        <property name="maximize_button">0</property>
+                        <property name="maximum_size"></property>
+                        <property name="min_size"></property>
+                        <property name="minimize_button">0</property>
+                        <property name="minimum_size"></property>
+                        <property name="moveable">1</property>
+                        <property name="name">reorder_panel</property>
+                        <property name="pane_border">1</property>
+                        <property name="pane_position"></property>
+                        <property name="pane_size"></property>
+                        <property name="permission">protected</property>
+                        <property name="pin_button">1</property>
+                        <property name="pos"></property>
+                        <property name="resize">Resizable</property>
+                        <property name="show">1</property>
+                        <property name="size"></property>
+                        <property name="subclass">; ; forward_declare</property>
+                        <property name="toolbar_pane">0</property>
+                        <property name="tooltip"></property>
+                        <property name="window_extra_style"></property>
+                        <property name="window_name"></property>
+                        <property name="window_style">wxTAB_TRAVERSAL</property>
+                        <object class="wxBoxSizer" expanded="1">
+                            <property name="minimum_size"></property>
+                            <property name="name">reorder_sizer</property>
+                            <property name="orient">wxVERTICAL</property>
+                            <property name="permission">none</property>
+                            <object class="sizeritem" expanded="1">
+                                <property name="border">5</property>
+                                <property name="flag">wxEXPAND</property>
+                                <property name="proportion">1</property>
+                                <object class="wxBoxSizer" expanded="1">
+                                    <property name="minimum_size"></property>
+                                    <property name="name">reorder_control_sizer</property>
+                                    <property name="orient">wxHORIZONTAL</property>
+                                    <property name="permission">none</property>
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag">wxALL</property>
+                                        <property name="proportion">0</property>
+                                        <object class="wxButton" expanded="1">
+                                            <property name="BottomDockable">1</property>
+                                            <property name="LeftDockable">1</property>
+                                            <property name="RightDockable">1</property>
+                                            <property name="TopDockable">1</property>
+                                            <property name="aui_layer"></property>
+                                            <property name="aui_name"></property>
+                                            <property name="aui_position"></property>
+                                            <property name="aui_row"></property>
+                                            <property name="auth_needed">0</property>
+                                            <property name="best_size"></property>
+                                            <property name="bg"></property>
+                                            <property name="bitmap"></property>
+                                            <property name="caption"></property>
+                                            <property name="caption_visible">1</property>
+                                            <property name="center_pane">0</property>
+                                            <property name="close_button">1</property>
+                                            <property name="context_help"></property>
+                                            <property name="context_menu">1</property>
+                                            <property name="current"></property>
+                                            <property name="default">0</property>
+                                            <property name="default_pane">0</property>
+                                            <property name="disabled"></property>
+                                            <property name="dock">Dock</property>
+                                            <property name="dock_fixed">0</property>
+                                            <property name="docking">Left</property>
+                                            <property name="drag_accept_files">0</property>
+                                            <property name="enabled">0</property>
+                                            <property name="fg"></property>
+                                            <property name="floatable">1</property>
+                                            <property name="focus"></property>
+                                            <property name="font"></property>
+                                            <property name="gripper">0</property>
+                                            <property name="hidden">0</property>
+                                            <property name="id">wxID_ANY</property>
+                                            <property name="label">Reorder</property>
+                                            <property name="margins"></property>
+                                            <property name="markup">0</property>
+                                            <property name="max_size"></property>
+                                            <property name="maximize_button">0</property>
+                                            <property name="maximum_size"></property>
+                                            <property name="min_size"></property>
+                                            <property name="minimize_button">0</property>
+                                            <property name="minimum_size"></property>
+                                            <property name="moveable">1</property>
+                                            <property name="name">reorder_reorder_button</property>
+                                            <property name="pane_border">1</property>
+                                            <property name="pane_position"></property>
+                                            <property name="pane_size"></property>
+                                            <property name="permission">protected</property>
+                                            <property name="pin_button">1</property>
+                                            <property name="pos"></property>
+                                            <property name="position"></property>
+                                            <property name="pressed"></property>
+                                            <property name="resize">Resizable</property>
+                                            <property name="show">1</property>
+                                            <property name="size"></property>
+                                            <property name="style"></property>
+                                            <property name="subclass">; ; forward_declare</property>
+                                            <property name="toolbar_pane">0</property>
+                                            <property name="tooltip">This will re-order a no-order block to align with current execution.&#x0A;&#x0A;It works by first creating a block of steps with no-order enabled. &#x0A;Then execute them through a TAS run. &#x0A;Then run the console command &quot;/reorder&quot; and copy the text to the input below. &#x0A;&#x0A;When using this functionality, each multibuild step will be unrolled and each rotation will be unrolled. After that the steps will be matched with the resulting order, which then replaces them.</property>
+                                            <property name="validator_data_type"></property>
+                                            <property name="validator_style">wxFILTER_NONE</property>
+                                            <property name="validator_type">wxDefaultValidator</property>
+                                            <property name="validator_variable"></property>
+                                            <property name="window_extra_style"></property>
+                                            <property name="window_name"></property>
+                                            <property name="window_style"></property>
+                                            <event name="OnButtonClick">OnReorderReorderButtonClicked</event>
+                                        </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag">wxALL|wxEXPAND</property>
+                                        <property name="proportion">1</property>
+                                        <object class="wxBoxSizer" expanded="1">
+                                            <property name="minimum_size"></property>
+                                            <property name="name">reorder_control_checkbox_sizer</property>
+                                            <property name="orient">wxHORIZONTAL</property>
+                                            <property name="permission">none</property>
+                                            <object class="sizeritem" expanded="1">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxALL</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxCheckBox" expanded="1">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="checked">1</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="drag_accept_files">0</property>
+                                                    <property name="enabled">1</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="label">Clear reorder</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">reorder_text_input_clear_checkbox</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size"></property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass">; ; forward_declare</property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip">Clears the text below after clicking on the Reorder button.</property>
+                                                    <property name="validator_data_type"></property>
+                                                    <property name="validator_style">wxFILTER_NONE</property>
+                                                    <property name="validator_type">wxDefaultValidator</property>
+                                                    <property name="validator_variable"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                </object>
+                                            </object>
+                                        </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag">wxEXPAND</property>
+                                        <property name="proportion">1</property>
+                                        <object class="wxBoxSizer" expanded="1">
+                                            <property name="minimum_size"></property>
+                                            <property name="name">reorder_locator_sizer</property>
+                                            <property name="orient">wxHORIZONTAL</property>
+                                            <property name="permission">none</property>
+                                            <object class="sizeritem" expanded="1">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxEXPAND</property>
+                                                <property name="proportion">1</property>
+                                                <object class="spacer" expanded="1">
+                                                    <property name="height">0</property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="width">375</property>
+                                                </object>
+                                            </object>
+                                            <object class="sizeritem" expanded="1">
+                                                <property name="border">5</property>
+                                                <property name="flag">wxALL</property>
+                                                <property name="proportion">0</property>
+                                                <object class="wxButton" expanded="1">
+                                                    <property name="BottomDockable">1</property>
+                                                    <property name="LeftDockable">1</property>
+                                                    <property name="RightDockable">1</property>
+                                                    <property name="TopDockable">1</property>
+                                                    <property name="aui_layer"></property>
+                                                    <property name="aui_name"></property>
+                                                    <property name="aui_position"></property>
+                                                    <property name="aui_row"></property>
+                                                    <property name="auth_needed">0</property>
+                                                    <property name="best_size"></property>
+                                                    <property name="bg"></property>
+                                                    <property name="bitmap"></property>
+                                                    <property name="caption"></property>
+                                                    <property name="caption_visible">1</property>
+                                                    <property name="center_pane">0</property>
+                                                    <property name="close_button">1</property>
+                                                    <property name="context_help"></property>
+                                                    <property name="context_menu">1</property>
+                                                    <property name="current"></property>
+                                                    <property name="default">0</property>
+                                                    <property name="default_pane">0</property>
+                                                    <property name="disabled"></property>
+                                                    <property name="dock">Dock</property>
+                                                    <property name="dock_fixed">0</property>
+                                                    <property name="docking">Left</property>
+                                                    <property name="drag_accept_files">0</property>
+                                                    <property name="enabled">0</property>
+                                                    <property name="fg"></property>
+                                                    <property name="floatable">1</property>
+                                                    <property name="focus"></property>
+                                                    <property name="font"></property>
+                                                    <property name="gripper">0</property>
+                                                    <property name="hidden">0</property>
+                                                    <property name="id">wxID_ANY</property>
+                                                    <property name="label">Locate</property>
+                                                    <property name="margins"></property>
+                                                    <property name="markup">0</property>
+                                                    <property name="max_size"></property>
+                                                    <property name="maximize_button">0</property>
+                                                    <property name="maximum_size"></property>
+                                                    <property name="min_size"></property>
+                                                    <property name="minimize_button">0</property>
+                                                    <property name="minimum_size"></property>
+                                                    <property name="moveable">1</property>
+                                                    <property name="name">reorder_locator_button</property>
+                                                    <property name="pane_border">1</property>
+                                                    <property name="pane_position"></property>
+                                                    <property name="pane_size"></property>
+                                                    <property name="permission">protected</property>
+                                                    <property name="pin_button">1</property>
+                                                    <property name="pos"></property>
+                                                    <property name="position"></property>
+                                                    <property name="pressed"></property>
+                                                    <property name="resize">Resizable</property>
+                                                    <property name="show">1</property>
+                                                    <property name="size"></property>
+                                                    <property name="style"></property>
+                                                    <property name="subclass">; ; forward_declare</property>
+                                                    <property name="toolbar_pane">0</property>
+                                                    <property name="tooltip">Finds the no-order block in the step list, helping you visualize that you are changing the correct block.</property>
+                                                    <property name="validator_data_type"></property>
+                                                    <property name="validator_style">wxFILTER_NONE</property>
+                                                    <property name="validator_type">wxDefaultValidator</property>
+                                                    <property name="validator_variable"></property>
+                                                    <property name="window_extra_style"></property>
+                                                    <property name="window_name"></property>
+                                                    <property name="window_style"></property>
+                                                    <event name="OnButtonClick">OnReorderLocatorButtonClicked</event>
+                                                </object>
+                                            </object>
+                                        </object>
+                                    </object>
+                                </object>
+                            </object>
+                            <object class="sizeritem" expanded="1">
+                                <property name="border">5</property>
+                                <property name="flag">wxEXPAND</property>
+                                <property name="proportion">1</property>
+                                <object class="wxBoxSizer" expanded="1">
+                                    <property name="minimum_size">-1,1200</property>
+                                    <property name="name">reorder_input_sizer</property>
+                                    <property name="orient">wxHORIZONTAL</property>
+                                    <property name="permission">none</property>
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag">wxALL|wxEXPAND</property>
+                                        <property name="proportion">1</property>
+                                        <object class="wxTextCtrl" expanded="1">
+                                            <property name="BottomDockable">1</property>
+                                            <property name="LeftDockable">1</property>
+                                            <property name="RightDockable">1</property>
+                                            <property name="TopDockable">1</property>
+                                            <property name="aui_layer"></property>
+                                            <property name="aui_name"></property>
+                                            <property name="aui_position"></property>
+                                            <property name="aui_row"></property>
+                                            <property name="best_size"></property>
+                                            <property name="bg"></property>
+                                            <property name="caption"></property>
+                                            <property name="caption_visible">1</property>
+                                            <property name="center_pane">0</property>
+                                            <property name="close_button">1</property>
+                                            <property name="context_help"></property>
+                                            <property name="context_menu">1</property>
+                                            <property name="default_pane">0</property>
+                                            <property name="dock">Dock</property>
+                                            <property name="dock_fixed">0</property>
+                                            <property name="docking">Left</property>
+                                            <property name="drag_accept_files">0</property>
+                                            <property name="enabled">1</property>
+                                            <property name="fg"></property>
+                                            <property name="floatable">1</property>
+                                            <property name="font"></property>
+                                            <property name="gripper">0</property>
+                                            <property name="hidden">0</property>
+                                            <property name="id">wxID_ANY</property>
+                                            <property name="max_size"></property>
+                                            <property name="maximize_button">0</property>
+                                            <property name="maximum_size"></property>
+                                            <property name="maxlength"></property>
+                                            <property name="min_size"></property>
+                                            <property name="minimize_button">0</property>
+                                            <property name="minimum_size">450,600</property>
+                                            <property name="moveable">1</property>
+                                            <property name="name">reorder_text_input</property>
+                                            <property name="pane_border">1</property>
+                                            <property name="pane_position"></property>
+                                            <property name="pane_size"></property>
+                                            <property name="permission">protected</property>
+                                            <property name="pin_button">1</property>
+                                            <property name="pos"></property>
+                                            <property name="resize">Resizable</property>
+                                            <property name="show">1</property>
+                                            <property name="size"></property>
+                                            <property name="style">wxTE_LEFT|wxTE_MULTILINE</property>
+                                            <property name="subclass">; ; forward_declare</property>
+                                            <property name="toolbar_pane">0</property>
+                                            <property name="tooltip">This will re-order a no-order block to align with current execution.&#x0A;&#x0A;It works by first creating a block of steps with no-order enabled. &#x0A;Then execute them through a TAS run. &#x0A;Then run the console command &quot;/reorder&quot; and copy the text to the input below. &#x0A;&#x0A;When using this functionality, each multibuild step will be unrolled and each rotation will be unrolled. After that the steps will be matched with the resulting order, which then replaces them.</property>
+                                            <property name="validator_data_type"></property>
+                                            <property name="validator_style">wxFILTER_NONE</property>
+                                            <property name="validator_type">wxDefaultValidator</property>
+                                            <property name="validator_variable"></property>
+                                            <property name="value"></property>
+                                            <property name="window_extra_style"></property>
+                                            <property name="window_name"></property>
+                                            <property name="window_style"></property>
+                                            <event name="OnText">OnReorderTextUpdate</event>
+                                        </object>
+                                    </object>
+                                </object>
+                            </object>
+                        </object>
+                    </object>
+                </object>
             </object>
         </object>
         <object class="Dialog" expanded="1">

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -1584,6 +1584,67 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	import_steps_panel->Layout();
 	import_steps_sizer->Fit( import_steps_panel );
 	main_book->AddPage( import_steps_panel, wxT("Import"), false, wxNullBitmap );
+	reorder_panel = new wxPanel( main_book, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	wxBoxSizer* reorder_sizer;
+	reorder_sizer = new wxBoxSizer( wxVERTICAL );
+
+	wxBoxSizer* reorder_control_sizer;
+	reorder_control_sizer = new wxBoxSizer( wxHORIZONTAL );
+
+	reorder_reorder_button = new wxButton( reorder_panel, wxID_ANY, wxT("Reorder"), wxDefaultPosition, wxDefaultSize, 0 );
+	reorder_reorder_button->Enable( false );
+	reorder_reorder_button->SetToolTip( wxT("This will re-order a no-order block to align with current execution.\n\nIt works by first creating a block of steps with no-order enabled. \nThen execute them through a TAS run. \nThen run the console command \"/reorder\" and copy the text to the input below. \n\nWhen using this functionality, each multibuild step will be unrolled and each rotation will be unrolled. After that the steps will be matched with the resulting order, which then replaces them.") );
+
+	reorder_control_sizer->Add( reorder_reorder_button, 0, wxALL, 5 );
+
+	wxBoxSizer* reorder_control_checkbox_sizer;
+	reorder_control_checkbox_sizer = new wxBoxSizer( wxHORIZONTAL );
+
+	reorder_text_input_clear_checkbox = new wxCheckBox( reorder_panel, wxID_ANY, wxT("Clear reorder"), wxDefaultPosition, wxDefaultSize, 0 );
+	reorder_text_input_clear_checkbox->SetValue(true);
+	reorder_text_input_clear_checkbox->SetToolTip( wxT("Clears the text below after clicking on the Reorder button.") );
+
+	reorder_control_checkbox_sizer->Add( reorder_text_input_clear_checkbox, 0, wxALL, 5 );
+
+
+	reorder_control_sizer->Add( reorder_control_checkbox_sizer, 1, wxALL|wxEXPAND, 5 );
+
+	wxBoxSizer* reorder_locator_sizer;
+	reorder_locator_sizer = new wxBoxSizer( wxHORIZONTAL );
+
+
+	reorder_locator_sizer->Add( 375, 0, 1, wxEXPAND, 5 );
+
+	reorder_locator_button = new wxButton( reorder_panel, wxID_ANY, wxT("Locate"), wxDefaultPosition, wxDefaultSize, 0 );
+	reorder_locator_button->Enable( false );
+	reorder_locator_button->SetToolTip( wxT("Finds the no-order block in the step list, helping you visualize that you are changing the correct block.") );
+
+	reorder_locator_sizer->Add( reorder_locator_button, 0, wxALL, 5 );
+
+
+	reorder_control_sizer->Add( reorder_locator_sizer, 1, wxEXPAND, 5 );
+
+
+	reorder_sizer->Add( reorder_control_sizer, 1, wxEXPAND, 5 );
+
+	wxBoxSizer* reorder_input_sizer;
+	reorder_input_sizer = new wxBoxSizer( wxHORIZONTAL );
+
+	reorder_input_sizer->SetMinSize( wxSize( -1,1200 ) );
+	reorder_text_input = new wxTextCtrl( reorder_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_LEFT|wxTE_MULTILINE );
+	reorder_text_input->SetToolTip( wxT("This will re-order a no-order block to align with current execution.\n\nIt works by first creating a block of steps with no-order enabled. \nThen execute them through a TAS run. \nThen run the console command \"/reorder\" and copy the text to the input below. \n\nWhen using this functionality, each multibuild step will be unrolled and each rotation will be unrolled. After that the steps will be matched with the resulting order, which then replaces them.") );
+	reorder_text_input->SetMinSize( wxSize( 450,600 ) );
+
+	reorder_input_sizer->Add( reorder_text_input, 1, wxALL|wxEXPAND, 5 );
+
+
+	reorder_sizer->Add( reorder_input_sizer, 1, wxEXPAND, 5 );
+
+
+	reorder_panel->SetSizer( reorder_sizer );
+	reorder_panel->Layout();
+	reorder_sizer->Fit( reorder_panel );
+	main_book->AddPage( reorder_panel, wxT("Reorder"), false, wxNullBitmap );
 
 
 	m_mgr.Update();
@@ -1745,6 +1806,9 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	import_steps_into_template_ctrl->Connect( wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler( GUI_Base::OnImportStepsIntoTemplateCtrlEnter ), NULL, this );
 	import_steps_into_template_btn->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnImportStepsIntoTemplateBtnClick ), NULL, this );
 	import_steps_text_import->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( GUI_Base::OnImportStepsTextUpdate ), NULL, this );
+	reorder_reorder_button->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnReorderReorderButtonClicked ), NULL, this );
+	reorder_locator_button->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnReorderLocatorButtonClicked ), NULL, this );
+	reorder_text_input->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( GUI_Base::OnReorderTextUpdate ), NULL, this );
 }
 
 GUI_Base::~GUI_Base()
@@ -1842,6 +1906,9 @@ GUI_Base::~GUI_Base()
 	import_steps_into_template_ctrl->Disconnect( wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler( GUI_Base::OnImportStepsIntoTemplateCtrlEnter ), NULL, this );
 	import_steps_into_template_btn->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnImportStepsIntoTemplateBtnClick ), NULL, this );
 	import_steps_text_import->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( GUI_Base::OnImportStepsTextUpdate ), NULL, this );
+	reorder_reorder_button->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnReorderReorderButtonClicked ), NULL, this );
+	reorder_locator_button->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnReorderLocatorButtonClicked ), NULL, this );
+	reorder_text_input->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( GUI_Base::OnReorderTextUpdate ), NULL, this );
 
 	m_mgr.UnInit();
 

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -207,6 +207,11 @@ class GUI_Base : public wxFrame
 		wxButton* import_steps_into_template_btn;
 		wxCheckBox* import_steps_clear_checkbox;
 		wxTextCtrl* import_steps_text_import;
+		wxPanel* reorder_panel;
+		wxButton* reorder_reorder_button;
+		wxCheckBox* reorder_text_input_clear_checkbox;
+		wxButton* reorder_locator_button;
+		wxTextCtrl* reorder_text_input;
 
 		// Virtual event handlers, override them in your derived class
 		virtual void OnApplicationClose( wxCloseEvent& event ) { event.Skip(); }
@@ -362,6 +367,9 @@ class GUI_Base : public wxFrame
 		virtual void OnImportStepsIntoTemplateCtrlEnter( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnImportStepsIntoTemplateBtnClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnImportStepsTextUpdate( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnReorderReorderButtonClicked( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnReorderLocatorButtonClicked( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnReorderTextUpdate( wxCommandEvent& event ) { event.Skip(); }
 
 
 	public:

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -253,6 +253,23 @@ protected:
 	void OnImportStepsIntoTemplateBtnClick(wxCommandEvent& event);
 	void OnImportStepsTextUpdate(wxCommandEvent& event);
 
+	//Reorder panel
+	struct ReorderStruct
+	{
+		int index,
+			step_number,
+			substep_number;
+	};
+	struct ReorderStep
+	{
+		Step step;
+		int step_number, substep_number;
+	};
+	void OnReorderReorderButtonClicked(wxCommandEvent& event);
+	void OnReorderLocatorButtonClicked(wxCommandEvent& event);
+	void OnReorderTextUpdate(wxCommandEvent& event);
+	bool OnReorderTextValidate(vector<ReorderStruct>& out);
+
 	//Main book
 	void OnMainBookPageChanged(wxAuiNotebookEvent& event);
 


### PR DESCRIPTION
No-order improvements to fast change step and debug message.
Added feature Re-order

### Re-order
Is a relatively simple feature. I gave it is own page in the main book, which is a bit overkill but we have enough room for pages.

1. It works by running no-order in the tas.
2. Then use a console command to get a text output
3. Then insert the text in the re-order panel

**Furthermore:** 
- Reorder handles clearing the text box. 
- Disabling the buttons when the text is invalid
- There is also a locator button to aid in visualizing the steps to reorder.

______
Undo is missing from this feature.

It is only possible to re-order 1 block at a time, and the block has to be valid (ei all steps must have been executed).

I made a quick GUI in the control script, if the feature becomes popular then that i will move the GUI part to one of my other mods.