### PR TITLE
Complete Undo / redo revamp.

### DIFF
--- a/src/CommandStack.cpp
+++ b/src/CommandStack.cpp
@@ -9,6 +9,7 @@ void CommandStack::Clear()
 
 void CommandStack::Push(Command command)
 {
+	if (command.empty()) return;
 	buffer[head] = command;
 	head = (head + 1) % size;
 	hair = head;
@@ -18,7 +19,7 @@ void CommandStack::Push(Command command)
 Command CommandStack::Pop()
 {
 	if (head == tail) 
-		return {0, T_NULL, {}};
+		return {{}, {}, ""};
 	head = (head + size - 1) % size;
 	return buffer[head];
 }
@@ -26,7 +27,7 @@ Command CommandStack::Pop()
 Command CommandStack::PopBack()
 {
 	if (head == hair)
-		return {0, T_NULL, {}};
+		return {{}, {}, ""};
 	int head_copy = head;
 	head = (head + 1) % size;
 	return buffer[head_copy];

--- a/src/CommandStack.h
+++ b/src/CommandStack.h
@@ -1,35 +1,43 @@
 #pragma once
 #include <vector>
 #include <string>
-#include <tuple>
 
 #include "Structures\Step.h"
 
 using std::vector;
 using std::string;
-using std::tuple;
 
-enum CommandType
+struct StepLine
 {
-	T_NULL, T_ADD, T_DELETE, T_MODIFY, 
-	T_MOVE_UP, T_MOVE_FIVE_UP, T_MOVE_DOWN, T_MOVE_FIVE_DOWN
+	int row;
+	Step step;
+
+	bool operator < (const StepLine& other) const
+	{
+		return row < other.row;
+	}
+	bool operator > (const StepLine& other) const
+	{
+		return row > other.row;
+	}
 };
+
 struct Command
 {
-	// The row the action happened at
-	int row;
-	// The type so it can be reversed
-	CommandType type;
-	// List of modified rows: Tuple of row index and row data
-	vector<tuple<int, Step>> rows;	 
+	vector<StepLine> before = {};
+	vector<StepLine> after = {};
+	string template_name = ""; // The name of the template or empty for steps grid
+
+	bool empty()
+	{
+		return before.empty() && after.empty();
+	}
 };
 
 class CommandStack
 {
-	// missing template actions
-
 private:
-	static inline const int size = 32;
+	static inline const int size = 128;
 	Command buffer[size] = {};
 	int head = 0, tail = 0, hair = 0;
 
@@ -41,4 +49,3 @@ public:
 	Command Pop();
 	Command PopBack();
 };
-

--- a/src/CommandStack.h
+++ b/src/CommandStack.h
@@ -2,25 +2,10 @@
 #include <vector>
 #include <string>
 
-#include "Structures\Step.h"
+#include "StepLine.h"
 
 using std::vector;
 using std::string;
-
-struct StepLine
-{
-	int row;
-	Step step;
-
-	bool operator < (const StepLine& other) const
-	{
-		return row < other.row;
-	}
-	bool operator > (const StepLine& other) const
-	{
-		return row > other.row;
-	}
-};
 
 struct Command
 {

--- a/src/Factorio-TAS-Generator.vcxproj
+++ b/src/Factorio-TAS-Generator.vcxproj
@@ -205,6 +205,7 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="DialogProgressBar.h" />
     <ClInclude Include="Settings.h" />
+    <ClInclude Include="StepLine.h" />
     <ClInclude Include="SteptypeColour.h" />
     <ClInclude Include="Structures\Building.h" />
     <ClInclude Include="Structures\GridEntry.h" />

--- a/src/Factorio-TAS-Generator.vcxproj.filters
+++ b/src/Factorio-TAS-Generator.vcxproj.filters
@@ -79,6 +79,9 @@
     <ClInclude Include="Structures\StepType.h">
       <Filter>Structs</Filter>
     </ClInclude>
+    <ClInclude Include="StepLine.h">
+      <Filter>Structs</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\Lua Files\control.lua">

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -305,7 +305,6 @@ void cMain::OnImportStepsIntoTemplateCtrlEnter(wxCommandEvent& event)
 	auto a = template_map.insert(std::pair<std::string, std::vector<Step>>(name, steps) );
 	for (int i = 0; i < steps.size(); i++) 
 	{
-		template_map[name].push_back(steps[i]);
 		change.after.push_back({i, steps[i]});
 	}
 

--- a/src/ImportStepsPanel.cpp
+++ b/src/ImportStepsPanel.cpp
@@ -45,12 +45,12 @@ bool ImportStepsPanel::update_segment()
 	return false;
 }
 
-bool ImportStepsPanel::extract_steps(wxString steps, vector<Step>& step_parameters, vector<Building> buildingSnapshot, int buildings_in_snap_shot)
+bool ImportStepsPanel::extract_steps(wxString steps_text, vector<Step>& steps, vector<Building> buildingSnapshot, int buildings_in_snap_shot)
 {
 	buildingsInSnapShot = buildings_in_snap_shot;
 	int counter = 0;
 	data = {};
-	data.str(steps.ToStdString());
+	data.str(steps_text.ToStdString());
 	while (update_segment())
 	{
 		counter++;
@@ -125,7 +125,7 @@ bool ImportStepsPanel::extract_steps(wxString steps, vector<Step>& step_paramete
 				break;
 		}
 
-		step_parameters.push_back(step);
+		steps.push_back(step);
 	}
 
 	return true;
@@ -138,7 +138,6 @@ void cMain::OnImportStepsIntoStepsIndexBtnClicked(wxCommandEvent& event)
 	auto row = rows.front();
 
 	import_steps_into_steps_ctrl->SetValue(row);
-	event.Skip();
 }
 
 void cMain::OnImportStepsIntoStepsIndexBtnRight(wxMouseEvent& event)
@@ -149,7 +148,6 @@ void cMain::OnImportStepsIntoStepsIndexBtnRight(wxMouseEvent& event)
 	auto totalRows = grid_steps->GetNumberRows();
 
 	import_steps_into_steps_ctrl->SetValue(row - totalRows);
-	event.Skip();
 }
 
 void cMain::OnImportStepsTextUpdate(wxCommandEvent& event)
@@ -180,7 +178,6 @@ void cMain::OnImportStepsTextUpdate(wxCommandEvent& event)
 		}
 		validateTemplateName();
 	}
-	event.Skip();
 }
 
 void cMain::OnImportStepsIntoStepsCtrl(wxSpinEvent& event)
@@ -202,7 +199,6 @@ void cMain::OnImportStepsIntoStepsCtrl(wxSpinEvent& event)
 		import_steps_into_steps_ctrl->SetBackgroundColour(wxColour("Red"));
 		import_steps_into_steps_btn->Enable(false);
 	}
-	event.Skip();
 }
 
 void cMain::OnImportStepsIntoStepsCtrlEnter(wxCommandEvent& event)
@@ -214,45 +210,36 @@ void cMain::OnImportStepsIntoStepsCtrlEnter(wxCommandEvent& event)
 void cMain::OnImportStepsIntoStepsBtnClick(wxCommandEvent& event)
 {
 	// validate steps
-	wxString steps = import_steps_text_import->GetValue();
-	vector<Step> step_parameters = {};
+	wxString steps_text = import_steps_text_import->GetValue();
+	vector<Step> steps = {};
 
 	// import steps
 	int row = import_steps_into_steps_ctrl->GetValue();
 	int rows = grid_steps->GetNumberRows();
 	int start = row >= 0 ? row : rows + row + 1;
 
-	if (!import_steps_panel->extract_steps(steps, step_parameters, BuildingsSnapShot, GenerateBuildingSnapShot(start))) return;
+	if (!import_steps_panel->extract_steps(steps_text, steps, BuildingsSnapShot, GenerateBuildingSnapShot(start))) return;
 
-	size_t steps_size = step_parameters.size();
+	grid_steps->InsertRows(start, steps.size());
 
-	grid_steps->InsertRows(start, steps_size);
+	Command change;
 
-	for (int i = 0; i < steps_size; i++)
+	for (int i = 0; i < steps.size(); i++)
 	{
-		GridEntry gridEntry = PrepareStepForGrid(&step_parameters[i]);
+		change.after.push_back({start + i, steps[i]});
+		GridEntry gridEntry = PrepareStepForGrid(&steps[i]);
 
 		PopulateGrid(grid_steps, start + i, &gridEntry);
 
-		BackgroundColorUpdate(grid_steps, start + i, step_parameters[i].type);
-
-		if (step_parameters[i].colour != wxNullColour)
-		{
-			wxColour colour = step_parameters[i].colour;
-			grid_steps->SetCellBackgroundColour(start + i, 1, colour);
-			grid_steps->SetCellBackgroundColour(start + i, 2, colour);
-			grid_steps->SetCellBackgroundColour(start + i, 3, colour);
-		}
+		BackgroundColorUpdate(grid_steps, start + i, steps[i]);
 	}
-	auto it1 = StepGridData.begin();
-	it1 += start;
-	StepGridData.insert(it1, step_parameters.begin(), step_parameters.end());
+
+	StepGridData.insert(StepGridData.begin() + start, steps.begin(), steps.end());
 
 	if (import_steps_clear_checkbox->IsChecked()) import_steps_text_import->Clear();
 
+	stack.Push(change);
 	no_changes = false;
-
-	event.Skip();
 }
 
 bool cMain::validateTemplateName()
@@ -286,7 +273,6 @@ bool cMain::validateTemplateName()
 void cMain::OnImportStepsIntoTemplateCtrlText(wxCommandEvent& event)
 {
 	validateTemplateName();
-	event.Skip();
 }
 
 void cMain::OnImportStepsIntoTemplateCtrlEnter(wxCommandEvent& event)
@@ -302,9 +288,8 @@ void cMain::OnImportStepsIntoTemplateCtrlEnter(wxCommandEvent& event)
 	}
 
 	// validate steps
-	wxString steps = import_steps_text_import->GetValue();
-	vector<Step> step_parameters = {};
-	if (!import_steps_panel->extract_steps(steps, step_parameters, BuildingsSnapShot, 0)) return;
+	vector<Step> steps = {};
+	if (!import_steps_panel->extract_steps(import_steps_text_import->GetValue(), steps, BuildingsSnapShot, 0)) return;
 
 	// create template
 	std::string name = import_steps_into_template_ctrl_validator.ToStdString();
@@ -315,8 +300,14 @@ void cMain::OnImportStepsIntoTemplateCtrlEnter(wxCommandEvent& event)
 	cmb_choose_template->SetValue(name);
 	cmb_choose_template->AutoComplete(template_choices);
 
-	auto a = template_map.insert(std::pair<std::string, std::vector<Step>>(name, step_parameters) );
-	for (int i = 0; i < step_parameters.size(); i++) template_map[name].push_back(step_parameters[i]);
+	Command change{.template_name = name};
+
+	auto a = template_map.insert(std::pair<std::string, std::vector<Step>>(name, steps) );
+	for (int i = 0; i < steps.size(); i++) 
+	{
+		template_map[name].push_back(steps[i]);
+		change.after.push_back({i, steps[i]});
+	}
 
 	UpdateTemplateGrid(template_map[name]);
 
@@ -324,9 +315,9 @@ void cMain::OnImportStepsIntoTemplateCtrlEnter(wxCommandEvent& event)
 
 	import_steps_into_template_btn->Enable(false);
 	import_steps_into_template_ctrl->SetForegroundColour(wxColour("Red"));
-	no_changes = false;
 
-	event.Skip();
+	stack.Push(change);
+	no_changes = false;
 }
 
 void cMain::OnImportStepsIntoTemplateBtnClick(wxCommandEvent& event)

--- a/src/StepLine.h
+++ b/src/StepLine.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <vector>
+#include "Structures\Step.h"
+
+using std::vector;
+
+// Simple pair of a row number and Step
+// Overloads comparison to the row number for easier sorting
+struct StepLine
+{
+	int row;
+	Step step;
+
+	bool operator < (const StepLine& other) const
+	{
+		return row < other.row;
+	}
+	bool operator > (const StepLine& other) const
+	{
+		return row > other.row;
+	}
+};
+
+// Simple pair of a starting row and a list of continues Steps
+struct StepBlock
+{
+	int row;
+	vector<Step> steps;
+};
+
+vector<StepBlock> static StepLineToStepBlock(vector<StepLine>& lines)
+{
+	vector<StepBlock> blocks{};
+	int prev = -2;
+
+	std::sort(lines.begin(), lines.end());
+	for (auto& stepline : lines)
+	{
+		if (prev + 1 == stepline.row)
+			blocks[blocks.size() - 1].steps.push_back(stepline.step);
+		else
+			blocks.push_back({stepline.row, {stepline.step}});
+		prev = stepline.row;
+	}
+
+	return blocks;
+}

--- a/src/TemplatePage.cpp
+++ b/src/TemplatePage.cpp
@@ -243,7 +243,7 @@ void cMain::TemplateMoveRow(wxGrid* grid, wxComboBox* cmb, bool move_up, map<str
 		}
 	}
 
-	UndoRedo(grid, data_list, VectorToBlocks(change.after), VectorToBlocks(change.before));
+	UndoRedo(grid, data_list, StepLineToStepBlock(change.after), StepLineToStepBlock(change.before));
 	stack.Push(change);
 	no_changes = false;
 }

--- a/src/WalkPanel.cpp
+++ b/src/WalkPanel.cpp
@@ -45,11 +45,7 @@ void cMain::CreateWalkStep(int x_modifier, int y_modifier)
 
 	auto step = Step(x + increment * x_modifier, y + increment * y_modifier);
 	step.type = e_walk;
-	stack.Push({
-		.row = row,
-		.type = T_ADD,
-		.rows = AddStep(row, step),
-	});
+	stack.Push({.after = AddStep(row, step)});
 
 	grid_steps->SelectRow(row);
 	grid_steps->GoToCell(row, 0);

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -309,9 +309,8 @@ private:
 	map<string, vector<Step>> template_map;
 
 	// Undo and redo
-	vector<std::pair<int, vector<Step>>> VectorToBlocks(vector<StepLine>& lines);
-	void UndoRedo(wxGrid* grid, vector<Step>& date_list, vector<std::pair<int, vector<Step>>> before, vector<std::pair<int, vector<Step>>> after);
-	void UndoRedoHandleTemplate(Command command, vector<std::pair<int, vector<Step>>> before, vector<std::pair<int, vector<Step>>> after);
+	void UndoRedo(wxGrid* grid, vector<Step>& date_list, vector<StepBlock> before, vector<StepBlock> after);
+	void UndoRedoHandleTemplate(Command command, vector<StepBlock> before, vector<StepBlock> after);
 	void OnUndoMenuSelected(wxCommandEvent& event);
 	void OnRedoMenuSelected(wxCommandEvent& event);
 	CommandStack stack;

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -309,6 +309,9 @@ private:
 	map<string, vector<Step>> template_map;
 
 	// Undo and redo
+	vector<std::pair<int, vector<Step>>> VectorToBlocks(vector<StepLine>& lines);
+	void UndoRedo(wxGrid* grid, vector<Step>& date_list, vector<std::pair<int, vector<Step>>> before, vector<std::pair<int, vector<Step>>> after);
+	void UndoRedoHandleTemplate(Command command, vector<std::pair<int, vector<Step>>> before, vector<std::pair<int, vector<Step>>> after);
 	void OnUndoMenuSelected(wxCommandEvent& event);
 	void OnRedoMenuSelected(wxCommandEvent& event);
 	CommandStack stack;
@@ -320,12 +323,13 @@ private:
 	bool ChecksBeforeResetWindow();
 	bool CheckBeforeClose();
 
-	void MoveRow(wxGrid* grid, bool up = false);
+	// if by is possitive then moves the rows down, and negative moves rows up
+	Command MoveRows(wxGrid* grid, int by = 1);
 	void TemplateMoveRow(wxGrid* grid, wxComboBox* cmb, bool up, map<string, vector<Step>>& map);
 	bool DeleteRow(wxGrid* grid, wxComboBox* cmb, map<string, vector<Step>>& map);
 	bool ChangeRow(wxGrid* grid, Step step);
 
-	void BackgroundColorUpdate(wxGrid* grid, int row, StepType step);
+	void BackgroundColorUpdate(wxGrid* grid, int row, Step& step);
 
 	void UpdateMapWithNewSteps(wxGrid* grid, wxComboBox* cmb, map<string, vector<Step>>& map);
 	void UpdateTemplateGrid(vector<Step>& steps);
@@ -354,9 +358,9 @@ private:
 	int GenerateBuildingSnapShot(int end_row);
 	void PopulateStepGrid();
 
-	vector<tuple<int, Step>> AddStep(int row, Step step, bool auto_put = true);
-	vector< tuple<int, Step>> ChangeStep(int row, Step step);
-	vector< tuple<int, Step>> DeleteSteps(wxArrayInt steps, bool auto_confirm = false);
+	vector<StepLine> AddStep(int row, Step step, bool auto_put = true);
+	Command ChangeStep(int row, Step step);
+	Command DeleteSteps(wxArrayInt steps, bool auto_confirm = false);
 	void GridTransfer(wxGrid* from, const int& fromRow, wxGrid* to, const int& toRow);
 	GridEntry ExtractGridEntry(wxGrid* grid, const int& row);
 


### PR DESCRIPTION
### Complete Undo / redo revamp.

- Changed the Command stack size to 128 from 32.
- Changed Commands to have a before,after. Simplifying the undo system. Added new struct StepLine
- Added undo to Templates
- Added undo to walk panel
- Added undo to import steps
- Added undo to force,skip,no_order buttons

Changed MoveRows to use the new undo system as its base function.

Changed BackgroundColorUpdate to also set step colour.

### New system
This new system is way simpler. You take a snap shot of what will be changed and another snap shot of what it was changed into. Which means it can back and forth between the before and after state.

A simple case is delete, where the before part will be the selected steps. While the after part is nothing.

### Templates
Templates are basically the same as the regular steps. However to make it work properly i needed to load the undone template into the template grid. Eventually i realized i would need to create destroyed templates, however undo does not delete templates.
____

This took longer than i care to admit, but the result speaks for itself.